### PR TITLE
security: Phase 0.1 — replace issue-author self-auth with live permission check

### DIFF
--- a/.github/scripts/authorize.sh
+++ b/.github/scripts/authorize.sh
@@ -1,15 +1,23 @@
 #!/usr/bin/env bash
 # Shared permission gate for opencraft1 agent workflows.
 #
-# Authorized IFF: ACTOR is on the allowlist, OR ACTOR == the GitHub login that
-# opened issue OWNER_ISSUE. This replaces contentos's OWNER/COLLABORATOR/MEMBER
-# association check with an author-rooted model.
+# Authorized IFF: ACTOR is on the allowlist, OR ACTOR has push access to the
+# repo (collaborator permission ∈ {admin, write}), checked live against the
+# GitHub API at execution time.
+#
+# WHY NOT "author of the originating issue": on a PUBLIC repo anyone is the
+# author of their own issue, so an author-rooted grant lets any anonymous user
+# self-authorize (open issue → /approved → dev flow). Authorization must be a
+# live permission check, never a property the actor controls. Labels/authorship
+# are state, not proof of authority. See docs/security-architecture.md (T1, #1).
 #
 # Required env:
 #   ACTOR             - github login that triggered the event
-#   OWNER_ISSUE       - issue number whose author is the "owner"
 #   GH_TOKEN          - token for gh lookups
 #   GITHUB_REPOSITORY - owner/repo
+# Optional env:
+#   OWNER_ISSUE       - originating issue number (informational only; no longer
+#                       used for authorization — kept so callers need not change)
 # Writes `authorized=true|false` to $GITHUB_OUTPUT and always exits 0 (callers
 # branch on the output; this script never hard-fails a run).
 set -uo pipefail
@@ -17,7 +25,6 @@ set -uo pipefail
 ALLOWLIST_FILE=".github/agents-allowlist.txt"
 
 : "${ACTOR:?ACTOR not set}"
-: "${OWNER_ISSUE:?OWNER_ISSUE not set}"
 : "${GH_TOKEN:?GH_TOKEN not set}"
 REPO="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY not set}"
 
@@ -39,12 +46,16 @@ if [ -f "$ALLOWLIST_FILE" ]; then
   done < "$ALLOWLIST_FILE"
 fi
 
-# 2) Author-of-originating-issue check.
-OWNER="$(gh issue view "$OWNER_ISSUE" --repo "$REPO" --json author --jq '.author.login' 2>/dev/null || echo "")"
-if [ -n "$OWNER" ] && [ "$OWNER" = "$ACTOR" ]; then
-  echo "authorize: '$ACTOR' is the author of issue #$OWNER_ISSUE."
-  emit true; exit 0
-fi
+# 2) Live repo-permission check. The API returns one of admin|write|read|none
+#    (maintain→write, triage→read). Only push-capable roles may steer agents.
+#    A non-collaborator resolves to "none" (or the call 404s) → not authorized.
+PERM="$(gh api "repos/$REPO/collaborators/$ACTOR/permission" --jq '.permission' 2>/dev/null || echo "")"
+case "$PERM" in
+  admin|write)
+    echo "authorize: '$ACTOR' has '$PERM' permission on $REPO."
+    emit true; exit 0
+    ;;
+esac
 
-echo "authorize: '$ACTOR' is neither author of #$OWNER_ISSUE ('$OWNER') nor on the allowlist."
+echo "authorize: '$ACTOR' is not on the allowlist and lacks push access (permission='${PERM:-unknown}')."
 emit false; exit 0

--- a/.github/workflows/dev-implement.yml
+++ b/.github/workflows/dev-implement.yml
@@ -86,7 +86,7 @@ jobs:
           # Authorization: pull_request path always ok; comment path needs auth=true.
           if [ "${{ github.event_name }}" = "issue_comment" ] && [ "${{ steps.auth.outputs.authorized }}" != "true" ]; then
             gh issue comment "${{ steps.resolve.outputs.issue }}" --repo ${{ github.repository }} \
-              --body "🤖 Only the issue author or an allowlisted maintainer can /approved this issue. Ignoring.
+              --body "🤖 Only a maintainer with write access (or an allowlisted maintainer) can /approved this issue. Ignoring.
           <sub>🤖 Dev · auth</sub><!-- agent-bot -->"
             echo "proceed=false" >> "$GITHUB_OUTPUT"; exit 0
           fi

--- a/.github/workflows/pm-followup.yml
+++ b/.github/workflows/pm-followup.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           gh issue comment ${{ github.event.issue.number }} \
             --repo ${{ github.repository }} \
-            --body "🤖 Only the issue author or an allowlisted maintainer can steer this issue's agent. Ignoring this comment.
+            --body "🤖 Only a maintainer with write access (or an allowlisted maintainer) can steer this issue's agent. Ignoring this comment.
           <sub>🤖 PM · auth</sub><!-- agent-bot -->"
 
       - name: Configure git


### PR DESCRIPTION
## what

Closes **T1 (self-authorization)** — the primary exploit the moment `opencraft1` goes public. Phase 0.1 of [`docs/security-implementation-plan.md`](docs/security-implementation-plan.md).

**Before:** `authorized = (allowlist) OR (ACTOR == author of the originating issue)`. On a public repo *everyone is the author of their own issue*, so the author branch lets any anonymous user self-authorize: open issue → `/approved` → `dev-implement`. Authorship is a property the actor controls, so it can never be proof of authority.

**After:** `authorized = (allowlist) OR (repo permission ∈ {admin, write})`, checked **live** via `gh api repos/.../collaborators/<actor>/permission` at execution time. Non-collaborators resolve to `none` → denied.

## why it's safe for the current (private) repo

- The only allowlisted user (`MishaMgla`, admin) still passes.
- Collaborators with push access still pass.
- Output contract (`authorized=true|false`) and always-exit-0 behavior unchanged → callers need no edits. `OWNER_ISSUE` is now optional/informational.

## verification

Stubbed-`gh` harness:

| actor | role | result |
|---|---|---|
| MishaMgla | allowlist | ✅ true |
| devwrite | write | ✅ true |
| admin1 | admin | ✅ true |
| triageuser | read | ⛔ false |
| anon123 | none | ⛔ false |

`bash -n` clean.

## scope

`authorize.sh` + the two user-facing reject messages (`pm-followup.yml`, `dev-implement.yml`) updated to match. This is a guardrail change → human-reviewed by design.

Depends conceptually on #19 (the architecture doc) but is independently mergeable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)