### PR TITLE
security: Phase 0.3/0.4 — main-protection ruleset + CODEOWNERS (config-as-doc)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,30 @@
+# CODEOWNERS — guardrail paths.
+#
+# Changes to these paths require a code-owner review and must never auto-merge.
+# This is the deterministic Tier-B forcing function from
+# docs/security-architecture.md (#8, T4): a bot cannot satisfy a human owner's
+# review, so any agent PR touching its own cage is hard-blocked.
+#
+# Enforcement: this file is INERT on its own. It only bites once the
+# "main protection" ruleset (.github/rulesets/main-protection.json) is applied
+# with `require_code_owner_review: true`. Apply via .github/scripts/apply-ruleset.sh.
+#
+# Non-guardrail paths have no owner here, so ordinary feature PRs still need
+# zero approvals and stay auto-mergeable — autonomy is preserved.
+
+# The agent cage itself: every workflow, script, prompt, allowlist, ruleset.
+/.github/                                @MishaMgla
+
+# Security design of record + rollout plan.
+/docs/security-architecture.md           @MishaMgla
+/docs/security-implementation-plan.md    @MishaMgla
+
+# Deploy / infra / secrets surface.
+/Dockerfile                              @MishaMgla
+/docs/deploy.md                          @MishaMgla
+
+# Dependency manifests & lockfiles (supply-chain surface).
+/go.mod                                  @MishaMgla
+/go.sum                                  @MishaMgla
+/web/package.json                        @MishaMgla
+/web/package-lock.json                   @MishaMgla

--- a/.github/rulesets/README.md
+++ b/.github/rulesets/README.md
@@ -1,0 +1,41 @@
+# branch rulesets (config-as-doc)
+
+`main-protection.json` is the intended GitHub ruleset for `main`. It is **not**
+auto-applied — a maintainer applies it with an admin token:
+
+```bash
+.github/scripts/apply-ruleset.sh
+```
+
+Implements Phase 0.3/0.4 of [`../../docs/security-implementation-plan.md`](../../docs/security-implementation-plan.md).
+
+## what it enforces on `main`
+
+- **PR required** (no direct pushes), **linear history**, **no force-push**, **no branch deletion**.
+- **Code-owner review required** (`require_code_owner_review: true`) → paired with
+  [`../CODEOWNERS`](../CODEOWNERS), any PR touching a guardrail path (`.github/**`, security docs,
+  Dockerfile, dependency manifests) needs the owner's approval and cannot auto-merge. This is the
+  Tier-B forcing function (#8, T4).
+- **Required status checks**: `go engine`, `web client`, `browser e2e` (the existing `tests` jobs).
+- **No bypass** (`bypass_actors: []`) — not even admins or Actions. The bot cannot merge around the gate.
+
+## deliberate choices / tradeoffs (review before applying)
+
+- **`required_approving_review_count: 0`** — ordinary feature PRs (no owned files) stay auto-mergeable, so
+  autonomy is preserved; only owned-file PRs require the code-owner approval. Verify your account sees the
+  code-owner requirement bite at count 0; if your org requires ≥1, raise it (and accept that all PRs then
+  need an approval).
+- **`required_signatures` omitted** — the dev agent commits via plain `git` on the runner, which is not
+  GPG-signed; requiring signatures would block the bot's own PRs. Add it once commits are signed (GitHub
+  App identity / sigstore).
+- **`strict_required_status_checks_policy: false`** — avoids forcing every autonomous PR to rebase on the
+  latest `main` before merge (churn under concurrent agent PRs). Flip to `true` for stricter safety once
+  the merge cadence is understood.
+- **`capability-gate` not yet required** — the keystone check (Phase 0.5) does not exist yet; requiring a
+  missing check would freeze all merges. Add `{ "context": "capability-gate" }` to `required_status_checks`
+  the moment that workflow lands, then re-apply.
+
+## not applied by automation, by design
+
+Applying a ruleset is a privileged admin action — keeping it a deliberate maintainer step (not a bot step)
+is itself part of the threat model: the agent must not be able to relax its own cage.

--- a/.github/rulesets/main-protection.json
+++ b/.github/rulesets/main-protection.json
@@ -1,0 +1,38 @@
+{
+  "name": "main protection",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/main"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    { "type": "required_linear_history" },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "require_code_owner_review": true,
+        "require_last_push_approval": false,
+        "dismiss_stale_reviews_on_push": true,
+        "required_review_thread_resolution": false
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": false,
+        "required_status_checks": [
+          { "context": "go engine" },
+          { "context": "web client" },
+          { "context": "browser e2e" }
+        ]
+      }
+    }
+  ],
+  "bypass_actors": []
+}

--- a/.github/scripts/apply-ruleset.sh
+++ b/.github/scripts/apply-ruleset.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Apply (create or update) the committed branch ruleset to the repo.
+#
+# Config-as-doc: .github/rulesets/main-protection.json is the source of truth;
+# this script pushes it to GitHub. Idempotent — matches an existing ruleset by
+# name and PUTs, otherwise POSTs.
+#
+# Requires a token with ADMIN on the repo (GITHUB_TOKEN's default repo scope is
+# NOT enough for rulesets). Run locally as a maintainer:
+#   gh auth login         # as a repo admin
+#   .github/scripts/apply-ruleset.sh
+#
+# Env:
+#   GITHUB_REPOSITORY  - owner/repo (default: MishaMgla/opencraft1)
+#   RULESET_FILE       - path to ruleset JSON (default: the committed one)
+set -euo pipefail
+
+REPO="${GITHUB_REPOSITORY:-MishaMgla/opencraft1}"
+RULESET_FILE="${RULESET_FILE:-.github/rulesets/main-protection.json}"
+
+[ -f "$RULESET_FILE" ] || { echo "::error::ruleset file not found: $RULESET_FILE"; exit 1; }
+command -v gh >/dev/null || { echo "::error::gh CLI not found"; exit 1; }
+command -v jq >/dev/null || { echo "::error::jq not found"; exit 1; }
+
+NAME="$(jq -r '.name' "$RULESET_FILE")"
+[ -n "$NAME" ] && [ "$NAME" != "null" ] || { echo "::error::ruleset .name missing in $RULESET_FILE"; exit 1; }
+
+EXISTING_ID="$(gh api "repos/$REPO/rulesets" --jq ".[] | select(.name==\"$NAME\") | .id" 2>/dev/null | head -1 || true)"
+
+if [ -n "${EXISTING_ID:-}" ]; then
+  echo "Updating ruleset '$NAME' (id $EXISTING_ID) on $REPO…"
+  gh api --method PUT "repos/$REPO/rulesets/$EXISTING_ID" --input "$RULESET_FILE" >/dev/null
+  echo "Updated."
+else
+  echo "Creating ruleset '$NAME' on $REPO…"
+  gh api --method POST "repos/$REPO/rulesets" --input "$RULESET_FILE" >/dev/null
+  echo "Created."
+fi


### PR DESCRIPTION
## what

Builds the **deterministic wall** around `main` and the **Tier-B forcing function** (#7–#9, T4 in [`docs/security-architecture.md`](docs/security-architecture.md)). Phase 0.3/0.4 of the rollout plan.

- **`.github/CODEOWNERS`** — guardrail paths (`.github/**`, security docs, `Dockerfile`, dependency manifests) owned by `@MishaMgla`. Non-guardrail paths have **no owner**, so ordinary feature PRs still need 0 approvals and stay auto-mergeable → **autonomy preserved**.
- **`.github/rulesets/main-protection.json`** — PR required, linear history, no force-push / deletion, `require_code_owner_review`, required checks (`go engine`, `web client`, `browser e2e`), **`bypass_actors: []`** (no admin/bot bypass). Matches the GitHub rulesets REST schema.
- **`.github/scripts/apply-ruleset.sh`** — idempotent create/update via `gh api` (needs an admin token).
- **`.github/rulesets/README.md`** — documents the deliberate tradeoffs.

## config-as-doc — not auto-applied

The ruleset is **not** applied by automation: relaxing the cage must be a deliberate maintainer action, never something the agent can do. A maintainer applies it once:

```bash
.github/scripts/apply-ruleset.sh   # with an admin-scoped gh token
```

## deliberate tradeoffs (please sanity-check before applying)

- `required_approving_review_count: 0` + `require_code_owner_review: true` → only **owned-file** PRs need the owner's approval; everything else auto-mergeable. Verify code-owner-at-0 bites on your account.
- `required_signatures` **omitted** — the dev agent's plain `git` commits aren't signed; requiring it would block the bot's own PRs. Add once commits are signed.
- `strict_required_status_checks_policy: false` — avoids forcing every autonomous PR to rebase before merge.
- `capability-gate` **not yet** a required check — that workflow (Phase 0.5) doesn't exist; requiring a missing check would freeze all merges. Add it the moment 0.5 lands.

## validation

JSON schema fields + all required rules present (`jq` assertion); `apply-ruleset.sh` `bash -n` clean; every CODEOWNERS path exists in the tree.

Part of the Phase 0 set with #20 (authorize fix) and #19 (architecture docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)