### PR TITLE
security(ruleset): fail apply-ruleset cleanly on 403 + document Pro/public requirement

### DIFF
--- a/.github/rulesets/README.md
+++ b/.github/rulesets/README.md
@@ -9,6 +9,12 @@ auto-applied — a maintainer applies it with an admin token:
 
 Implements Phase 0.3/0.4 of [`../../docs/security-implementation-plan.md`](../../docs/security-implementation-plan.md).
 
+> **plan requirement.** Rulesets / branch protection are **disabled on a free private repo** — GitHub
+> returns `403 "Upgrade to GitHub Pro or make this repository public"`. They are free on **public** repos
+> (and available on Pro/Team for private). So this ruleset **activates at the moment the repo goes public**,
+> which is exactly when its protection is needed; until then it stays config-as-doc and `apply-ruleset.sh`
+> will fail with that 403. Enforcement therefore can't be smoke-tested while the repo is free+private.
+
 ## what it enforces on `main`
 
 - **PR required** (no direct pushes), **linear history**, **no force-push**, **no branch deletion**.

--- a/.github/scripts/apply-ruleset.sh
+++ b/.github/scripts/apply-ruleset.sh
@@ -25,9 +25,22 @@ command -v jq >/dev/null || { echo "::error::jq not found"; exit 1; }
 NAME="$(jq -r '.name' "$RULESET_FILE")"
 [ -n "$NAME" ] && [ "$NAME" != "null" ] || { echo "::error::ruleset .name missing in $RULESET_FILE"; exit 1; }
 
-EXISTING_ID="$(gh api "repos/$REPO/rulesets" --jq ".[] | select(.name==\"$NAME\") | .id" 2>/dev/null | head -1 || true)"
+# List existing rulesets. This fails on a free PRIVATE repo (rulesets require a
+# PUBLIC repo or GitHub Pro/Team), so surface that cause instead of pressing on.
+ERR="$(mktemp)"
+if ! RULESETS_JSON="$(gh api "repos/$REPO/rulesets" 2>"$ERR")"; then
+  echo "::error::could not list rulesets on $REPO." >&2
+  echo "Rulesets / branch protection need a PUBLIC repo or GitHub Pro/Team. GitHub said:" >&2
+  sed 's/^/  /' "$ERR" >&2
+  rm -f "$ERR"; exit 1
+fi
+rm -f "$ERR"
 
-if [ -n "${EXISTING_ID:-}" ]; then
+# Match by name; only accept a numeric id (guards against parsing an error body).
+EXISTING_ID="$(printf '%s' "$RULESETS_JSON" | jq -r ".[] | select(.name==\"$NAME\") | .id" | head -1)"
+[[ "$EXISTING_ID" =~ ^[0-9]+$ ]] || EXISTING_ID=""
+
+if [ -n "$EXISTING_ID" ]; then
   echo "Updating ruleset '$NAME' (id $EXISTING_ID) on $REPO…"
   gh api --method PUT "repos/$REPO/rulesets/$EXISTING_ID" --input "$RULESET_FILE" >/dev/null
   echo "Updated."


### PR DESCRIPTION
Follow-up to #21 after applying the ruleset surfaced a 403 on the free private repo.

**Finding:** rulesets / branch protection are disabled on a free **private** repo (`403 "Upgrade to GitHub Pro or make this repository public"`); free on **public**. So `main protection` activates at the moment the repo goes public — exactly when it's needed. Not a config bug.

**Fixes:**
- `apply-ruleset.sh` — detect the failed `gh api .../rulesets` GET and exit 1 with the cause, instead of capturing the error JSON as the ruleset id and PUTting to a garbage URL (the confusing output seen on the first run). Numeric-id guard added.
- `rulesets/README.md` — documents the Pro/public requirement.

Verified: `bash -n` clean; simulated-403 path prints the cause and exits 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)