### PR TITLE
security: Phase 0.5 — capability diff-gate (keystone)

### DIFF
--- a/.github/rulesets/README.md
+++ b/.github/rulesets/README.md
@@ -22,7 +22,8 @@ Implements Phase 0.3/0.4 of [`../../docs/security-implementation-plan.md`](../..
   [`../CODEOWNERS`](../CODEOWNERS), any PR touching a guardrail path (`.github/**`, security docs,
   Dockerfile, dependency manifests) needs the owner's approval and cannot auto-merge. This is the
   Tier-B forcing function (#8, T4).
-- **Required status checks**: `go engine`, `web client`, `browser e2e` (the existing `tests` jobs).
+- **Required status checks**: `go engine`, `web client`, `browser e2e` (the `tests` jobs) and
+  `capability-gate` (the keystone diff-gate — Tier B fails the check, blocking auto-merge).
 - **No bypass** (`bypass_actors: []`) — not even admins or Actions. The bot cannot merge around the gate.
 
 ## deliberate choices / tradeoffs (review before applying)
@@ -37,9 +38,9 @@ Implements Phase 0.3/0.4 of [`../../docs/security-implementation-plan.md`](../..
 - **`strict_required_status_checks_policy: false`** — avoids forcing every autonomous PR to rebase on the
   latest `main` before merge (churn under concurrent agent PRs). Flip to `true` for stricter safety once
   the merge cadence is understood.
-- **`capability-gate` not yet required** — the keystone check (Phase 0.5) does not exist yet; requiring a
-  missing check would freeze all merges. Add `{ "context": "capability-gate" }` to `required_status_checks`
-  the moment that workflow lands, then re-apply.
+- **`capability-gate` is now required** — the keystone check (Phase 0.5, `.github/workflows/policy-gate.yml`)
+  exists and runs on every PR, so it is listed in `required_status_checks`. It only *blocks* once this
+  ruleset is applied (i.e. at the public flip).
 
 ## not applied by automation, by design
 

--- a/.github/rulesets/main-protection.json
+++ b/.github/rulesets/main-protection.json
@@ -29,7 +29,8 @@
         "required_status_checks": [
           { "context": "go engine" },
           { "context": "web client" },
-          { "context": "browser e2e" }
+          { "context": "browser e2e" },
+          { "context": "capability-gate" }
         ]
       }
     }

--- a/.github/scripts/capability-gate.sh
+++ b/.github/scripts/capability-gate.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Capability diff-gate — the KEYSTONE (docs/security-architecture.md #3/#4).
+#
+# Classifies a PR by the CAPABILITIES its diff introduces, not by the issue text.
+# The unit of trust is the merged diff: a schema-valid PRD or a "small feature"
+# can still carry a payload that runs later where secrets/users live. So this
+# gate reasons about what the diff can DO.
+#
+#   Tier A  -> within a low-capability envelope; auto-merge eligible. exit 0.
+#   Tier B  -> needs a human; any capability signal or ambiguity. exit 1.
+#
+# Default-deny: any signal => Tier B. This v1 is heuristic and deliberately
+# biased toward false-positives (a human looks); gitleaks/semgrep harden it later.
+# Rules are the tunable block below.
+#
+# Input (one of):
+#   GATE_DIFF_FILE      - path to a unified diff to analyze (tests/CI)
+#   BASE_SHA, HEAD_SHA  - compute `git diff BASE HEAD`
+# Output:
+#   markdown report -> stdout (+ $GITHUB_STEP_SUMMARY if set)
+#   tier=A|B -> $GITHUB_OUTPUT if set
+#   exit 0 (Tier A) / 1 (Tier B) / 2 (bad invocation)
+set -uo pipefail
+
+MAX_ADDED_LINES="${MAX_ADDED_LINES:-600}"
+
+# --- obtain the diff ---
+if [ -n "${GATE_DIFF_FILE:-}" ]; then
+  DIFF="$(cat "$GATE_DIFF_FILE")"
+elif [ -n "${BASE_SHA:-}" ] && [ -n "${HEAD_SHA:-}" ]; then
+  DIFF="$(git diff "$BASE_SHA" "$HEAD_SHA")"
+else
+  echo "::error::capability-gate needs GATE_DIFF_FILE or BASE_SHA+HEAD_SHA" >&2
+  exit 2
+fi
+
+FILES="$(printf '%s\n' "$DIFF" | sed -nE 's;^\+\+\+ b/;;p')"
+ADDED="$(printf '%s\n' "$DIFF" | grep -E '^\+' | grep -vE '^\+\+\+' || true)"
+ADDED_COUNT="$(printf '%s\n' "$ADDED" | grep -c . || true)"
+FILE_COUNT="$(printf '%s\n' "$FILES" | grep -c . || true)"
+
+reasons=()
+match_path() { printf '%s\n' "$FILES" | grep -qiE "$1"; }
+match_add()  { printf '%s\n' "$ADDED" | grep -qiE "$1"; }
+
+# --- path-based signals (strongest; least false-prone) ---
+match_path '(^|/)\.github/' \
+  && reasons+=("touches CI / automation / the agent cage (.github/**)")
+match_path '(^|/)(go\.mod|go\.sum|package(-lock)?\.json|yarn\.lock|pnpm-lock\.yaml|Cargo\.(toml|lock)|requirements\.txt|Gemfile(\.lock)?)$' \
+  && reasons+=("changes a dependency manifest / lockfile (supply chain)")
+match_path '(^|/)Dockerfile($|\.)|(^|/)docker-compose|\.dockerfile$' \
+  && reasons+=("changes container / build (Dockerfile)")
+match_path '(deploy|railway|(^|/)vercel\.(json|ts)|\.tf$|(^|/)\.env)' \
+  && reasons+=("touches deploy / infra / env config")
+match_path '(^|[/_.-])(auth|cors|secret|secrets|security)([/_.-]|$)' \
+  && reasons+=("touches an auth / cors / security-named path")
+match_path '(migration|\.sql$|(^|[/_.-])schema([/_.-]|$))' \
+  && reasons+=("touches a DB migration / schema (RLS surface)")
+
+# --- content-based signals on ADDED lines ---
+match_add '\b(curl|wget)\b|fetch\(|http\.(Get|Post|NewRequest)|axios|requests\.(get|post)|urllib|XMLHttpRequest' \
+  && reasons+=("adds an outbound network call")
+match_add 'exec\.Command|child_process|subprocess|os\.system|\beval\(|new Function\(|vm\.runIn' \
+  && reasons+=("adds dynamic exec / subprocess")
+match_add 'SECRET|TOKEN|API[_-]?KEY|_KEY\b|PASSWORD|PRIVATE_KEY|SERVICE_ROLE|CREDENTIAL' \
+  && reasons+=("references a secret-like identifier")
+if printf '%s\n' "$ADDED" | grep -oiE 'https?://[a-z0-9._-]+' \
+     | grep -viE '(github\.com|githubusercontent|localhost|127\.0\.0\.1|example\.(com|org)|opencraft1\.(com|vercel\.app)|pixijs|jsdelivr|unpkg)' \
+     | grep -q .; then
+  reasons+=("adds an external URL literal")
+fi
+
+# --- size envelope ---
+if [ "${ADDED_COUNT:-0}" -gt "$MAX_ADDED_LINES" ]; then
+  reasons+=("large diff: $ADDED_COUNT added lines > $MAX_ADDED_LINES")
+fi
+
+# --- verdict ---
+if [ "${#reasons[@]}" -eq 0 ]; then TIER=A; else TIER=B; fi
+
+{
+  echo "## Capability diff-gate — Tier $TIER"
+  echo
+  if [ "$TIER" = A ]; then
+    echo "✅ **Tier A** — within the low-capability envelope. Auto-merge eligible."
+  else
+    echo "⛔ **Tier B** — human review required. Capability signals:"
+    for r in "${reasons[@]}"; do echo "- $r"; done
+  fi
+  echo
+  echo "_Heuristic gate v1 (docs/security-architecture.md #3/#4). ${ADDED_COUNT:-0} added lines across ${FILE_COUNT:-0} files._"
+} | tee -a "${GITHUB_STEP_SUMMARY:-/dev/null}"
+
+[ -n "${GITHUB_OUTPUT:-}" ] && echo "tier=$TIER" >> "$GITHUB_OUTPUT"
+
+[ "$TIER" = A ] && exit 0 || exit 1

--- a/.github/workflows/policy-gate.yml
+++ b/.github/workflows/policy-gate.yml
@@ -1,0 +1,44 @@
+name: capability-gate
+
+# The keystone (docs/security-architecture.md #3/#4): classify every PR by the
+# CAPABILITIES its diff introduces. Tier A passes (auto-merge eligible); Tier B
+# fails (human required). Runs on the untrusted `pull_request` event — read-only
+# token, no secrets — so it is safe against fork PRs and prompt-injected diffs.
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write   # best-effort labeling only; downgraded to read on forks
+
+jobs:
+  capability-gate:
+    name: capability-gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Classify diff
+        id: gate
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: .github/scripts/capability-gate.sh
+
+      # Best-effort: mirror the tier onto a label. Skipped on fork PRs (the
+      # default token is read-only there); never fails the gate.
+      - name: Label tier
+        if: always() && github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          TIER: ${{ steps.gate.outputs.tier }}
+        run: |
+          [ -z "${TIER:-}" ] && exit 0
+          if [ "$TIER" = "A" ]; then ADD="auto:tier-a"; RM="needs-human"; else ADD="needs-human"; RM="auto:tier-a"; fi
+          gh pr edit "$PR" --repo "$GITHUB_REPOSITORY" --add-label "$ADD" 2>/dev/null || true
+          gh pr edit "$PR" --repo "$GITHUB_REPOSITORY" --remove-label "$RM" 2>/dev/null || true

--- a/docs/security-implementation-plan.md
+++ b/docs/security-implementation-plan.md
@@ -47,13 +47,17 @@ branches `codex/issue-*`.
   automerge.
 
 **0.5 — capability diff-gate (KEYSTONE)** *(#3/#4)*
-- where: new required workflow `policy-gate.yml` + `.github/policy/` rules.
-- change: on every agent PR, run `gitleaks` (no secrets added) + `semgrep` (no new egress / `curl|bash` /
-  eval / subprocess / dynamic import) + dependency-allowlist & lockfile-diff gate + path/capability
-  classifier. **default-deny ambiguity.** emit the Tier (A/B); Tier B → require human. make it a
-  **required, non-bypassable** check in the ruleset.
-- done-check: a PR adding `fetch(env.SECRET)` or a new dependency fails the gate; a docs-only PR passes as
-  Tier A.
+- where: `.github/scripts/capability-gate.sh` + `.github/workflows/policy-gate.yml`.
+- change: on every PR, classify the *diff's* capabilities (path denylist + content signals: deps, outbound
+  network, dynamic exec, secret-like identifiers, external URLs, diff size). **default-deny ambiguity** →
+  Tier B fails the check; Tier A passes. Registered in the ruleset `required_status_checks` as
+  `capability-gate`. Runs on the untrusted `pull_request` event (read-only, no secrets).
+- status: **classifier + check shipped** (v1, heuristic). done-check met — verified: docs-only / ordinary
+  feature / `author`-path → Tier A (pass); new dependency / `fetch(process.env.SECRET)` / workflow edit /
+  external URL / >600-line diff → Tier B (fail).
+- follow-up (not in this step): (a) wire the existing automerge paths (`auto-merge-spec.sh`,
+  dev-implement) to refuse Tier B; (b) harden with `gitleaks` + `semgrep` to catch what regex misses
+  (Layer #6: auth-in-app-code, RLS, symlinks).
 
 ---
 


### PR DESCRIPTION
## what

The **keystone** (#3/#4 in [`docs/security-architecture.md`](docs/security-architecture.md)): classify every PR by the **capabilities of its diff**, not by the issue text. Tier A → pass (auto-merge eligible); Tier B → fail (human required). Default-deny.

- **`.github/scripts/capability-gate.sh`** — path denylist (`.github/**`, dep manifests, Dockerfile, deploy/env, auth/cors/security, migrations/SQL) + content signals on added lines (outbound network, dynamic exec, secret-like identifiers, external URLs) + diff-size envelope. Any signal → Tier B (`exit 1`); clean → Tier A (`exit 0`).
- **`.github/workflows/policy-gate.yml`** — runs the gate on the **untrusted `pull_request` event** (read-only token, no secrets; safe on fork PRs). Check name `capability-gate`; best-effort tier label.
- **`main-protection.json`** — `capability-gate` added to required status checks (blocks once the ruleset is applied at the public flip).

## verification

Synthetic-diff harness:

| diff | tier |
|---|---|
| docs-only | ✅ A |
| ordinary feature (`web/src/*.ts`) | ✅ A |
| `author`-path (false-positive guard) | ✅ A |
| new dependency (`go.mod`) | ⛔ B |
| `fetch(process.env.SUPABASE_SERVICE_ROLE_KEY)` | ⛔ B |
| workflow edit (`.github/**`) | ⛔ B |
| external URL literal | ⛔ B |
| >600-line diff | ⛔ B |

## expected: this PR's own `capability-gate` check is RED

This PR edits `.github/**`, so the gate correctly classifies **its own diff as Tier B** — a live demonstration that the guardrail-path denylist works. It doesn't block merge (the ruleset isn't applied yet) and is itself a guardrail change that warrants human review by design.

## follow-ups (not here)

(a) wire `auto-merge-spec.sh` / dev-implement to refuse Tier B; (b) add `gitleaks` + `semgrep` for what regex misses (auth-in-app-code, RLS, symlinks).

Phase 0.5 of the rollout plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)