### PR TITLE
security: Phase 0.2 (partial) — secret-segmentation guard

### DIFF
--- a/.github/scripts/check-secret-segmentation.sh
+++ b/.github/scripts/check-secret-segmentation.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Secret-segmentation guard (docs/security-architecture.md #2, T3).
+#
+# Workflows that run an agent (codex) over attacker-controlled issue text must
+# never reference a production secret — otherwise one prompt injection exfiltrates
+# it. This is a deterministic regression guard: it FAILS CI if an agent workflow
+# gains a prod secret. It does not touch the live flow; it only reads YAML.
+#
+# Finding it encodes: today prod secrets (VERCEL_*) live only in deploy-client.yml;
+# the agent workflows carry GITHUB_TOKEN (required, per-job scoped) + AUTO_PAT
+# (a real-user PAT for the merge cascade). AUTO_PAT is a tracked exception pending
+# the Phase 1.2 auto-merge-isolation refactor — warned, not failed.
+set -uo pipefail
+
+# Workflows that execute an agent over untrusted issue text.
+AGENT_WORKFLOWS=(pm-intake pm-followup dev-implement dev-revise)
+
+# Production / high-value secrets that must never appear in an agent job.
+PROD_SECRET_RE='secrets\.(VERCEL_[A-Z_]+|SUPABASE_[A-Z_]+|RAILWAY_[A-Z_]+|DATABASE_[A-Z_]+|[A-Z_]*_API_KEY|[A-Z_]*_SECRET|[A-Z_]*_PRIVATE_KEY|OPENAI_[A-Z_]+|ANTHROPIC_[A-Z_]+)'
+
+fail=0
+for w in "${AGENT_WORKFLOWS[@]}"; do
+  f=".github/workflows/$w.yml"
+  [ -f "$f" ] || { echo "warn: $f not found (skipping)"; continue; }
+
+  hits="$(grep -noE "$PROD_SECRET_RE" "$f" || true)"
+  if [ -n "$hits" ]; then
+    echo "::error file=$f::agent workflow references a production secret (violates secret segmentation):"
+    printf '%s\n' "$hits" | sed 's/^/    /'
+    fail=1
+  fi
+
+  if grep -qE 'secrets\.AUTO_PAT' "$f"; then
+    echo "::warning file=$f::$w co-locates AUTO_PAT (privileged PAT) with agent execution — isolate via the Phase 1.2 auto-merge refactor."
+  fi
+done
+
+if [ "$fail" -ne 0 ]; then
+  echo "Secret segmentation: FAILED."
+  exit 1
+fi
+echo "Secret segmentation: OK — no production secrets in agent workflows."

--- a/.github/workflows/secret-segmentation.yml
+++ b/.github/workflows/secret-segmentation.yml
@@ -1,0 +1,24 @@
+name: secret-segmentation
+
+# Deterministic guard (docs/security-architecture.md #2, T3): fail if a workflow
+# that runs an agent over untrusted issue text gains a production secret. Read-only,
+# no secrets — it only inspects YAML. Runs when workflows or the check change.
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+      - '.github/scripts/check-secret-segmentation.sh'
+
+permissions:
+  contents: read
+
+jobs:
+  secret-segmentation:
+    name: secret-segmentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - run: .github/scripts/check-secret-segmentation.sh

--- a/docs/security-implementation-plan.md
+++ b/docs/security-implementation-plan.md
@@ -24,11 +24,19 @@ branches `codex/issue-*`.
   trigger `dev-implement`; an allowlisted/write user still does.
 
 **0.2 — secret segmentation** *(T3)*
-- where: every workflow `env:` / `secrets:` usage; new `deploy.yml`.
-- change: untrusted jobs (PM, security) get **zero secrets**; dev job gets **no prod secrets**; move all
-  prod secrets (Supabase, deploy) into a single deploy job. add explicit per-job `permissions:` (least
-  privilege); remove repo-wide secret exposure.
-- done-check: `grep` shows no prod secret referenced in PM/dev jobs; deploy job is the only consumer.
+- finding (audited): prod-deploy secrets are **already segmented** — `VERCEL_*` live only in
+  `deploy-client.yml` (a standalone `push`-triggered job); **no agent workflow references Vercel / Supabase
+  / Railway secrets**. The only prod-grade credential co-resident with agent execution is **`AUTO_PAT`** (a
+  real-user PAT used so the merge cascades to downstream workflows), present in all four agent workflows.
+- shipped: `.github/scripts/check-secret-segmentation.sh` + `.github/workflows/secret-segmentation.yml` —
+  a deterministic guard that **fails CI if an agent workflow gains a prod secret**, locking in the
+  invariant. It warns (does not fail) on the `AUTO_PAT` exception. Verified: current tree passes; an
+  injected `secrets.SUPABASE_*` fails it.
+- follow-up (delicate — do **with** Phase 1.2, with testing, not blind): isolate `AUTO_PAT` into a no-agent
+  merge job/workflow so the privileged PAT never co-resides with untrusted-input agent execution. Coupled
+  to ephemeral runners (1.2), since a persistent runner is the real exfil window. Also add explicit
+  least-privilege per-job `permissions:` and drop unused `id-token: write`.
+- done-check: guard green on every PR; (follow-up) `grep` shows no `AUTO_PAT` in any agent-execution job.
 
 **0.3 — branch-protection ruleset on `main`** *(T4, wall)*
 - where: GitHub repo ruleset (config-as-doc; record the intended ruleset in this repo).


### PR DESCRIPTION
## audit finding

Prod-deploy secrets are **already segmented**: `VERCEL_*` live only in `deploy-client.yml` (a standalone `push`-triggered job), and **no agent workflow references Vercel / Supabase / Railway secrets**. The only prod-grade credential co-resident with agent execution is **`AUTO_PAT`** — a real-user PAT used so a merge cascades to downstream workflows (a `GITHUB_TOKEN` merge wouldn't) — present in all four agent workflows.

## what ships (the safe, enforceable part)

A deterministic guard that **fails CI if an agent workflow gains a production secret**, locking in the invariant:

- `.github/scripts/check-secret-segmentation.sh` — denies prod-secret patterns (`VERCEL_* / SUPABASE_* / RAILWAY_* / *_API_KEY / *_SECRET / …`) in `pm-intake`, `pm-followup`, `dev-implement`, `dev-revise`; **warns** (doesn't fail) on the `AUTO_PAT` exception.
- `.github/workflows/secret-segmentation.yml` — runs it on PRs touching workflows (read-only, no secrets).

Verified: current tree **passes** (with 4 `AUTO_PAT` warnings); an injected `secrets.SUPABASE_SERVICE_ROLE_KEY` makes it **exit 1**.

## deliberately NOT done here

Fully isolating `AUTO_PAT` into a no-agent merge job is a **delicate refactor of the live merge/cascade flow** — best done **with Phase 1.2 (ephemeral runners)** and real testing, since a persistent runner is the actual exfil window. Doing it blind risks freezing the autonomous pipeline. Tracked as the 0.2 follow-up in the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)