### PR TITLE
security: Phase 2.1 — hold Tier B impl PRs from auto-merge

### DIFF
--- a/.github/scripts/capability-gate-pr.sh
+++ b/.github/scripts/capability-gate-pr.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Run the capability gate (.github/scripts/capability-gate.sh) on a PR's diff,
+# INLINE inside dev-implement / dev-revise — because agent-opened PRs are created
+# with GITHUB_TOKEN, which does NOT trigger the pull_request policy-gate workflow.
+# So the gate that protects auto-merge has to run in the same job, like run-gates.sh.
+#
+# Usage:   capability-gate-pr.sh <pr-number>
+# Env:     GH_TOKEN (for gh), GITHUB_REPOSITORY
+# Output:  tier=A|B -> $GITHUB_OUTPUT (via capability-gate.sh); exit 0 (A) / 1 (B).
+set -uo pipefail
+
+PR="${1:?usage: capability-gate-pr.sh <pr-number>}"
+REPO="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY not set}"
+
+HEAD_REF="$(gh pr view "$PR" --repo "$REPO" --json headRefName --jq '.headRefName')"
+[ -n "$HEAD_REF" ] || { echo "::error::could not resolve head branch for PR #$PR"; exit 2; }
+
+git fetch --no-tags --quiet origin main "$HEAD_REF" 2>/dev/null || true
+
+BASE_SHA="$(git merge-base origin/main "origin/$HEAD_REF" 2>/dev/null || git rev-parse origin/main)"
+HEAD_SHA="$(git rev-parse "origin/$HEAD_REF")"
+
+echo "capability-gate-pr: PR #$PR ($HEAD_REF) diff ${BASE_SHA:0:8}..${HEAD_SHA:0:8}"
+export BASE_SHA HEAD_SHA
+exec .github/scripts/capability-gate.sh

--- a/.github/workflows/dev-implement.yml
+++ b/.github/workflows/dev-implement.yml
@@ -185,8 +185,30 @@ jobs:
         if: steps.implpr.outputs.gate == 'true'
         run: .github/scripts/run-gates.sh
 
-      - name: Auto-merge on green
+      # Keystone (docs/security-architecture.md #3/#4): classify the impl diff's
+      # capabilities INLINE — agent PRs are opened with GITHUB_TOKEN, which does
+      # not trigger the pull_request policy-gate workflow, so the gate that guards
+      # auto-merge must run here, like run-gates.sh. Tier B holds for a human.
+      - name: Capability gate (Tier)
+        id: capgate
         if: steps.implpr.outputs.gate == 'true'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: .github/scripts/capability-gate-pr.sh ${{ steps.implpr.outputs.pr }}
+
+      - name: Hold Tier B for human
+        if: steps.implpr.outputs.gate == 'true' && steps.capgate.outputs.tier != 'A'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR=${{ steps.implpr.outputs.pr }}
+          gh pr edit "$PR" --repo ${{ github.repository }} --add-label needs-human || true
+          gh pr comment "$PR" --repo ${{ github.repository }} --body "🤖 Capability gate: **Tier B** — this diff introduces capabilities that need human review before merge (see the run summary). Not auto-merging. A maintainer can review and merge.
+          <sub>🤖 Dev · capability-gate</sub><!-- agent-bot -->"
+
+      - name: Auto-merge on green
+        if: steps.implpr.outputs.gate == 'true' && steps.capgate.outputs.tier == 'A'
         env:
           GH_TOKEN: ${{ secrets.AUTO_PAT }}
         run: |

--- a/docs/security-implementation-plan.md
+++ b/docs/security-implementation-plan.md
@@ -95,8 +95,18 @@ branches `codex/issue-*`.
 ## Phase 2 — tiering & deploy
 
 **2.1 — capability Tier A/B classifier wired to merge** *(#4)*
-- change: the gate's Tier output drives automerge eligibility; Tier A auto-merges, Tier B → `needs-human`.
-- done-check: Tier A feature auto-merges end-to-end; Tier B halts for review.
+- shipped: `dev-implement.yml` runs `.github/scripts/capability-gate-pr.sh` **inline** before "Auto-merge
+  on green" (agent PRs open with `GITHUB_TOKEN`, which does NOT trigger the `pull_request` policy-gate, so
+  the gate must run in-job like `run-gates.sh`). Tier A → auto-merge; Tier B → `needs-human` label + comment,
+  **no auto-merge** (fail-closed: empty/error tier also holds).
+- deliberately NOT gated: the markdown **spec-PR** auto-merge (`auto-merge-spec.sh`) — PRDs are prose and
+  trip content signals (the security doc itself classifies Tier B), and they carry no executable risk;
+  gating them would freeze the cascade. The human `/merge` path (`dev-revise`) is left as-is (a write-access
+  maintainer is already the human in the loop).
+- follow-up: add a `docs/**` / prose exemption to the content signals so docs PRs aren't needlessly Tier B;
+  optionally annotate (not block) `dev-revise`.
+- done-check: an impl PR with a clean diff auto-merges; one adding a dep / outbound call / secret ref gets
+  `needs-human` and is not auto-merged. Classifier verified on real commit ranges.
 
 **2.2 — decouple deploy, OIDC, build-without-secrets, human gate first** *(#10)*
 - where: new `deploy.yml` + GitHub Environment.


### PR DESCRIPTION
## what

Wires the capability gate (keystone, #23) into the **autonomous merge path**, so a high-capability diff can't auto-merge to `main`.

Agent-opened impl PRs are created with `GITHUB_TOKEN`, which **does not trigger** the `pull_request` policy-gate workflow — so the gate runs **inline** in `dev-implement` (exactly like `run-gates.sh`).

- **`.github/scripts/capability-gate-pr.sh`** — resolve a PR's head branch, diff vs the merge-base with `main`, run `capability-gate.sh`.
- **`dev-implement.yml`** — new `Capability gate (Tier)` step → `Hold Tier B for human` (`needs-human` label + comment) → `Auto-merge on green` now requires `tier == 'A'`. **Fail-closed**: empty/error tier also holds.

## scope (deliberate)

- **Gated:** the autonomous impl-PR auto-merge (where code lands).
- **Not gated:** the markdown **spec-PR** auto-merge — PRDs are prose, trip content signals (the security doc itself is Tier B), and carry no executable risk; gating would freeze the cascade.
- **Unchanged:** the human `/merge` path (`dev-revise`) — a write-access maintainer is already the human in the loop.

## verification

YAML parses; `capability-gate-pr.sh` plumbing exercised on real commit ranges (`.github` range → Tier B / exit 1); `secret-segmentation` guard still green (only `GITHUB_TOKEN` added).

## follow-up

`docs/**`/prose exemption for content signals (so docs PRs aren't needlessly Tier B); optionally annotate (not block) `dev-revise`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)