### PR TITLE
security: Codex subscription everywhere + model tiering (gpt-5.4 PM / gpt-5.5 dev); drop OIDC

### DIFF
--- a/.github/workflows/pm-followup.yml
+++ b/.github/workflows/pm-followup.yml
@@ -132,7 +132,7 @@ jobs:
           gh auth setup-git
           codex exec \
             --cd "$GITHUB_WORKSPACE" \
-            --model gpt-5.5 \
+            --model gpt-5.4 \
             -c model_reasoning_effort="medium" \
             --sandbox danger-full-access \
             --skip-git-repo-check \

--- a/.github/workflows/pm-intake.yml
+++ b/.github/workflows/pm-intake.yml
@@ -61,7 +61,7 @@ jobs:
           gh auth setup-git
           codex exec \
             --cd "$GITHUB_WORKSPACE" \
-            --model gpt-5.5 \
+            --model gpt-5.4 \
             -c model_reasoning_effort="medium" \
             --sandbox danger-full-access \
             --skip-git-repo-check \

--- a/docs/security-architecture.md
+++ b/docs/security-architecture.md
@@ -73,8 +73,8 @@ two ideas carry the design.
 ```
 issue / comment  (UNTRUSTED text)
       │
-      ▼  UNTRUSTED PLANE  · no secrets · read-only token · ephemeral runner · egress allowlist
-      │                   · no web/file tools · metered OpenAI API key + small model (NOT the Codex session)
+      ▼  UNTRUSTED PLANE  · no app/prod secrets · read-only token · ephemeral runner · egress allowlist
+      │                   · no web/file tools · Codex session present (gpt-5.4) — isolation (#6) protects it
  ┌──────────────────────────────────────────────────────────────────┐
  │ security-audit agent  → structured verdict {enum, confidence, …}  │
  │ PM agent              → bounded discussion → structured PRD (tainted, carries provenance) │
@@ -87,14 +87,14 @@ issue / comment  (UNTRUSTED text)
  │   · path policy · dedupe · rate limit · permission re-check       │
  └──────────────────────────────────────────────────────────────────┘
       │   PRD that passes → spec PR on pm/issue-* branch
-      ▼  TRUSTED DEV PLANE · daily cron · Codex session · NO prod secrets · sandboxed · egress-restricted
+      ▼  TRUSTED DEV PLANE · daily cron · Codex session (gpt-5.5) · NO prod secrets · sandboxed · egress-restricted
  ┌──────────────────────────────────────────────────────────────────┐
  │ dev agent implements against the tainted spec → impl PR (codex/issue-*) │
  └──────────────────────────────────────────────────────────────────┘
       │   branch protection + required checks + capability diff-gate (all deterministic, non-bypassable)
       ▼
    merge to main   ──DECOUPLED──▶   DEPLOY PLANE · the ONLY secret-bearing job
-                                    · OIDC short-lived creds · build without prod secrets
+                                    · GitHub Environment secrets (scoped to this job) · build w/o prod secrets
                                     · env protection (human gate initially)
 ```
 
@@ -128,10 +128,13 @@ grouped by the layer they live in. the implementation order is in the companion 
    - **Tier B (human required):** anything else, or capability-gate confidence below threshold.
 
 ### planes, runner, billing
-5. **plane-split billing** (resolves the session-credential risk *and* the cost goal). the **Codex
-   subscription session lives only on the trusted dev runner**; the untrusted PM/security classifier runs on
-   a **cheap metered OpenAI API key + a small model** (classification spend is tiny). the expensive dev work
-   stays on subscription.
+5. **Codex subscription everywhere + model tiering** (owner decision, 2026-06: no metered API key). Every
+   agent — PM, security, dev — runs on the **Codex subscription session**. Cost is managed by **model tier**,
+   not by billing plane: **PM + security → `gpt-5.4`** (cheaper); **dev → `gpt-5.5`**. The consequence: the
+   subscription session *is* present in the untrusted PM/security jobs, so it is a high-value credential
+   there — its protection rests **entirely on runner isolation (#6)**: ephemeral disposable runner + egress
+   allowlist mean a prompt injection can neither persist nor exfiltrate the session. **#6 is therefore the
+   sole control standing between an injected PM prompt and the Codex credential — it must be solid.**
 6. **runner hardening.** self-hosted stays (subscription billing; public-repo runner minutes are free under
    2026 pricing) but becomes **a disposable VM per job**, not just an `--ephemeral` runner *process*.
    egress allowlist (enumerate the real endpoints — `api.github.com`, `objects.githubusercontent.com`,
@@ -160,8 +163,10 @@ grouped by the layer they live in. the implementation order is in the companion 
 
 ### deploy
 10. **decouple deploy from merge.** merge ≠ deploy. deploy is a separate workflow in the deploy plane (the
-    only secret-bearing job). use **OIDC short-lived creds**, **build without prod secrets**, inject runtime
-    secrets at the hosting platform. environment protection rules can be non-human (wait timer, deployment-
+    only secret-bearing job). deploy secrets live in a **GitHub Environment** (owner decision, 2026-06: no
+    OIDC — Environment secrets are acceptable), exposed **only** to the deploy job that references that
+    environment, gated by the environment's protection rules. (OIDC short-lived creds remain a future
+    nice-to-have, not required.) environment protection rules can be non-human (wait timer, deployment-
     branch restriction) **but those govern *when/where*, not *whether the diff is safe*** — so zero-human
     deploy is defensible **only if the capability gate (#3) is excellent**. start with a human deploy gate;
     drop it once the gate has earned trust.

--- a/docs/security-implementation-plan.md
+++ b/docs/security-implementation-plan.md
@@ -71,11 +71,15 @@ branches `codex/issue-*`.
 
 ## Phase 1 — plane split & runner hardening
 
-**1.1 — split billing across planes** *(#5)*
-- change: untrusted PM/security → metered **OpenAI API key + small model** (new secret, scoped, spend-
-  capped); trusted dev → keep the **Codex subscription session**, on a **separate runner label**. untrusted
-  jobs physically cannot reach the Codex session.
-- done-check: PM job has no access to the Codex session/creds; dev job runs on the `trusted` runner only.
+**1.1 — Codex subscription everywhere + model tiering** *(#5)* — owner decision (2026-06): **no metered API
+key**; keep the Codex subscription for all agents and economize by model tier.
+- shipped: PM (`pm-intake`, `pm-followup`) and the future security agent → **`gpt-5.4`**; dev
+  (`dev-implement`, `dev-revise`) stays **`gpt-5.5`**.
+- consequence: the subscription session is now present in the untrusted PM/security jobs, so it is a
+  high-value credential there. Its sole protection is **runner isolation (1.2)** — ephemeral + egress
+  allowlist — so 1.2 is now load-bearing, not optional.
+- done-check: PM runs on `gpt-5.4`, dev on `gpt-5.5`; (after 1.2) an injected PM prompt cannot persist or
+  exfiltrate the session.
 
 **1.2 — disposable, egress-restricted runners** *(#6, T7)*
 - change: one **disposable VM per job** (not just `--ephemeral` process); egress allowlist (enumerate real
@@ -98,13 +102,15 @@ branches `codex/issue-*`.
 - change: the gate's Tier output drives automerge eligibility; Tier A auto-merges, Tier B → `needs-human`.
 - done-check: Tier A feature auto-merges end-to-end; Tier B halts for review.
 
-**2.2 — decouple deploy, OIDC, build-without-secrets, human gate first** *(#10)*
-- where: new `deploy.yml` + GitHub Environment.
-- change: deploy separate from merge; OIDC short-lived creds; build without prod secrets, inject at hosting
-  platform; environment protection with a **human approval gate initially** (relax to wait-timer/branch-
-  restriction only once 0.5 is proven).
-- done-check: a merge to `main` does not auto-deploy; deploy requires the gate; build job holds no prod
-  secrets.
+**2.2 — decouple deploy, Environment secrets, human gate first** *(#10)* — owner decision (2026-06): **no
+OIDC**; deploy secrets live in a GitHub Environment.
+- where: new `deploy.yml` (or keep `deploy-client.yml`) bound to a protected GitHub **Environment**.
+- change: deploy separate from merge; deploy secrets stored as **Environment secrets**, exposed **only** to
+  the deploy job that references that environment; environment protection with a **human approval gate
+  initially** (relax to wait-timer / branch-restriction once the capability gate is proven). OIDC remains a
+  future nice-to-have, not required.
+- done-check: a merge to `main` does not auto-deploy; deploy requires the environment gate; no agent job
+  can read the Environment secrets.
 
 ---
 


### PR DESCRIPTION
Implements two owner decisions and records their security consequences.

## 1.1 — no metered API key; model tiering instead
Keep the **Codex subscription** for every agent; economize by **model tier**:
- PM (`pm-intake`, `pm-followup`) and the future security agent → **`gpt-5.4`**
- dev (`dev-implement`, `dev-revise`) → **`gpt-5.5`** (unchanged)

**Security consequence (recorded in the docs):** the subscription session is now present in the untrusted PM jobs, so it's a high-value credential there. Its sole protection becomes **runner isolation (1.2)** — ephemeral + egress allowlist. **1.2 is now load-bearing, not optional.**

## 2.2 — no OIDC
Deploy secrets live in a **protected GitHub Environment**, scoped to the deploy job only. OIDC stays a future nice-to-have.

## changes
- `pm-intake.yml`, `pm-followup.yml`: `--model gpt-5.5` → `gpt-5.4`.
- `docs/security-architecture.md` (#5, #10, diagram) + plan (1.1, 2.2) updated.

> If `codex` rejects `gpt-5.4` on the runner, revert those two lines to `gpt-5.5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)