### PR TITLE
security: Phase 3.2 — global AGENTS_FREEZE kill switch

### DIFF
--- a/.github/workflows/dev-implement.yml
+++ b/.github/workflows/dev-implement.yml
@@ -14,6 +14,7 @@ jobs:
     #      the Authorize step below).
     if: |
       github.repository == 'MishaMgla/opencraft1' &&
+      vars.AGENTS_FREEZE != 'true' &&
       (
         (
           github.event_name == 'pull_request' &&

--- a/.github/workflows/dev-revise.yml
+++ b/.github/workflows/dev-revise.yml
@@ -11,6 +11,7 @@ jobs:
     # allowlist check is the Authorize step (keyed to the originating issue).
     if: |
       github.repository == 'MishaMgla/opencraft1' &&
+      vars.AGENTS_FREEZE != 'true' &&
       github.event.issue.pull_request != null &&
       github.event.comment.user.login != 'github-actions[bot]' &&
       !contains(github.event.comment.body, '<!-- agent-bot -->') &&

--- a/.github/workflows/pm-followup.yml
+++ b/.github/workflows/pm-followup.yml
@@ -11,6 +11,7 @@ jobs:
     # not /approved (that is dev-implement), not the // discuss escape hatch.
     if: |
       github.repository == 'MishaMgla/opencraft1' &&
+      vars.AGENTS_FREEZE != 'true' &&
       github.event.issue.pull_request == null &&
       github.event.comment.user.login != 'github-actions[bot]' &&
       !contains(github.event.comment.body, '<!-- agent-bot -->') &&

--- a/.github/workflows/pm-intake.yml
+++ b/.github/workflows/pm-intake.yml
@@ -10,6 +10,7 @@ jobs:
     # collaborators by the private repo). `pm:skip` opts an issue out.
     if: |
       github.repository == 'MishaMgla/opencraft1' &&
+      vars.AGENTS_FREEZE != 'true' &&
       !contains(github.event.issue.labels.*.name, 'pm:skip')
     runs-on: [self-hosted]
     permissions:

--- a/docs/agents-killswitch.md
+++ b/docs/agents-killswitch.md
@@ -1,0 +1,47 @@
+# agent kill switch
+
+A global freeze for the autonomous agent flow (Phase 3.2 of
+[`security-implementation-plan.md`](security-implementation-plan.md), control #15).
+
+## how it works
+
+Each agent workflow (`pm-intake`, `pm-followup`, `dev-implement`, `dev-revise`) gates its job on a repo
+**Actions variable** `AGENTS_FREEZE`:
+
+```yaml
+if: |
+  github.repository == 'MishaMgla/opencraft1' &&
+  vars.AGENTS_FREEZE != 'true' &&
+  ...
+```
+
+When `AGENTS_FREEZE == 'true'`, those jobs are skipped — **no agent (codex) runs, no comment, no merge.**
+Unset/anything-else → agents run normally (fail-safe default).
+
+The protective workflows — `policy-gate` (capability gate), `secret-segmentation`, and `tests` — are
+**deliberately not** frozen: they only inspect PRs and must keep running even during a freeze.
+
+## freeze / unfreeze
+
+```bash
+# freeze (halts all agents immediately; in-flight jobs finish, new ones don't start)
+gh variable set AGENTS_FREEZE --repo MishaMgla/opencraft1 --body true
+
+# unfreeze
+gh variable set AGENTS_FREEZE --repo MishaMgla/opencraft1 --body false
+# or: gh variable delete AGENTS_FREEZE --repo MishaMgla/opencraft1
+
+# check
+gh variable list --repo MishaMgla/opencraft1
+```
+
+Setting it needs a token with repo admin / `actions:write`. A repo variable (not a secret) is used so its
+state is visible in Settings → Secrets and variables → Actions.
+
+## when to use
+
+- A prompt-injection or abuse incident is suspected.
+- A bad merge / runaway loop is in progress.
+- Cost spike, or you're mid-migration and want the flow paused.
+
+Pair with alerting (Telegram) once that lands so a freeze is announced.

--- a/docs/security-implementation-plan.md
+++ b/docs/security-implementation-plan.md
@@ -117,11 +117,15 @@ branches `codex/issue-*`.
 - done-check: an issue can't loop forever; a duplicate is linked+closed; spend cap trips the freeze.
 
 **3.2 — observability, kill switch, alerts, new-account friction** *(#13/#15/#16)*
-- change: Langfuse tracing with redaction + retention + **no tracing of secret jobs**; `agents:freeze`
-  kill switch checked first by every workflow; Telegram alerts on block/policy-fail/Tier-B/merge/deploy/
-  cost-breach; new/zero-rep accounts → discussion-only until trust accrues.
-- done-check: setting `agents:freeze` halts all agent workflows; traces contain no secrets; a brand-new
-  account's issue does not auto-advance to dev.
+- shipped: **kill switch** — repo Actions variable `AGENTS_FREEZE`; each agent workflow gates its job on
+  `vars.AGENTS_FREEZE != 'true'` (protective workflows policy-gate / secret-segmentation / tests stay
+  running). `gh variable set AGENTS_FREEZE --body true` halts all agents. See
+  [`agents-killswitch.md`](agents-killswitch.md).
+- remaining: Langfuse tracing with redaction + retention + **no tracing of secret jobs**; Telegram alerts on
+  block/policy-fail/Tier-B/merge/deploy/cost-breach; new/zero-rep accounts → discussion-only until trust
+  accrues.
+- done-check: setting `AGENTS_FREEZE=true` halts all agent workflows; (remaining) traces contain no secrets;
+  a brand-new account's issue does not auto-advance to dev.
 
 ---
 


### PR DESCRIPTION
## what

A fail-safe **global kill switch** for the autonomous agent flow (control #15).

Each agent workflow (`pm-intake`, `pm-followup`, `dev-implement`, `dev-revise`) gates its job on a repo Actions variable:

```yaml
if: |
  github.repository == 'MishaMgla/opencraft1' &&
  vars.AGENTS_FREEZE != 'true' &&
  ...
```

`AGENTS_FREEZE == 'true'` → those jobs skip: **no codex run, no comment, no merge.** Unset/other → agents run (fail-safe default).

The **protective** workflows (`policy-gate`, `secret-segmentation`, `tests`) are deliberately **not** frozen — they only inspect PRs and must keep running during a freeze.

## use

```bash
gh variable set AGENTS_FREEZE --repo MishaMgla/opencraft1 --body true    # freeze
gh variable set AGENTS_FREEZE --repo MishaMgla/opencraft1 --body false   # unfreeze
```

Docs: `docs/agents-killswitch.md`.

## verification

All four workflows parse; freeze guard present in each; guard workflows untouched.

Phase 3.2 (partial — tracing/alerts/new-account friction remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)