### PR TITLE
security: Phase 3.1 — PM intake abuse/sprawl controls

### DIFF
--- a/.github/scripts/abuse-gate.sh
+++ b/.github/scripts/abuse-gate.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Phase 3.1 abuse / sprawl controls for the OPEN PM intake (control #11).
+#
+# pm-intake runs the PM agent on every new issue from anyone, so it is the
+# untrusted entry point. This gate decides whether the agent should run, and
+# applies soft friction. It NEVER merges or changes code — worst case it skips an
+# agent run. FAIL-OPEN: on a GitHub API error it allows (don't lock out legit
+# users) but logs a warning.
+#
+# Env (required): ISSUE, ACTOR, GH_TOKEN, GITHUB_REPOSITORY
+# Env (tunable):  NEW_ACCOUNT_DAYS=30  AUTHOR_ISSUES_24H=5  DAILY_INTAKE_CAP=50
+# Output: proceed=true|false (+ reason) to $GITHUB_OUTPUT.
+set -uo pipefail
+
+: "${ISSUE:?ISSUE not set}"
+: "${ACTOR:?ACTOR not set}"
+: "${GH_TOKEN:?GH_TOKEN not set}"
+REPO="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY not set}"
+NEW_ACCOUNT_DAYS="${NEW_ACCOUNT_DAYS:-30}"
+AUTHOR_ISSUES_24H="${AUTHOR_ISSUES_24H:-5}"
+DAILY_INTAKE_CAP="${DAILY_INTAKE_CAP:-50}"
+
+emit() {
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    { echo "proceed=$1"; echo "reason=$2"; } >> "$GITHUB_OUTPUT"
+  fi
+  echo "abuse-gate: proceed=$1 — $2"
+}
+say() {  # post a throwaway comment; never fail the gate on a comment error
+  gh issue comment "$ISSUE" --repo "$REPO" --body "$1
+<sub>🤖 PM · abuse-gate</sub><!-- agent-bot -->" 2>/dev/null || true
+}
+add_label() { gh issue edit "$ISSUE" --repo "$REPO" --add-label "$1" 2>/dev/null || true; }
+is_int() { [[ "${1:-}" =~ ^[0-9]+$ ]]; }
+
+# --- 1) per-author rate limit: issues opened in the last 24h ---
+SINCE="$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo '')"
+if [ -n "$SINCE" ]; then
+  N_AUTHOR="$(gh api -X GET search/issues \
+    --raw-field q="repo:$REPO type:issue author:$ACTOR created:>=$SINCE" \
+    --jq '.total_count' 2>/dev/null || echo '')"
+  if is_int "$N_AUTHOR" && [ "$N_AUTHOR" -gt "$AUTHOR_ISSUES_24H" ]; then
+    say "⏳ Rate limit: you've opened $N_AUTHOR issues in 24h (max $AUTHOR_ISSUES_24H). This one is paused — a maintainer can pick it up. Please consolidate requests."
+    add_label "rate-limited"
+    emit false "author-rate-limit ($N_AUTHOR/$AUTHOR_ISSUES_24H in 24h)"
+    exit 0
+  fi
+fi
+
+# --- 2) daily intake cap (cost/abuse circuit-breaker; subscription has no $ meter) ---
+TODAY="$(date -u +%Y-%m-%d)"
+N_RUNS="$(gh api -X GET "repos/$REPO/actions/workflows/pm-intake.yml/runs" \
+  --raw-field created=">=$TODAY" --jq '.total_count' 2>/dev/null || echo '')"
+if is_int "$N_RUNS" && [ "$N_RUNS" -gt "$DAILY_INTAKE_CAP" ]; then
+  say "🛑 Daily intake cap reached ($N_RUNS runs today, cap $DAILY_INTAKE_CAP). Agent intake is paused for today — a maintainer can review. (Set \`AGENTS_FREEZE\` to halt entirely.)"
+  add_label "needs-human"
+  emit false "daily-intake-cap ($N_RUNS/$DAILY_INTAKE_CAP today)"
+  exit 0
+fi
+
+# --- 3) new-account friction (label only; PM still responds = discussion) ---
+CREATED="$(gh api "users/$ACTOR" --jq '.created_at' 2>/dev/null || echo '')"
+if [ -n "$CREATED" ]; then
+  C_S="$(date -u -d "$CREATED" +%s 2>/dev/null || echo '')"
+  NOW_S="$(date -u +%s)"
+  if is_int "$C_S"; then
+    AGE_DAYS=$(( (NOW_S - C_S) / 86400 ))
+    if [ "$AGE_DAYS" -lt "$NEW_ACCOUNT_DAYS" ]; then
+      add_label "discussion-only"
+      echo "abuse-gate: '$ACTOR' account is $AGE_DAYS days old (< $NEW_ACCOUNT_DAYS) — labelled discussion-only."
+    fi
+  fi
+fi
+
+# --- 4) dedupe (non-blocking): flag a likely-duplicate open issue by title overlap ---
+TITLE="$(gh issue view "$ISSUE" --repo "$REPO" --json title --jq '.title' 2>/dev/null || echo '')"
+if [ -n "$TITLE" ]; then
+  # significant words (len>=4), search other OPEN issues' titles for any of them
+  WORDS="$(printf '%s' "$TITLE" | tr 'A-Z' 'a-z' | tr -cs 'a-z0-9' '\n' | awk 'length>=4' | head -6 | paste -sd' ' -)"
+  if [ -n "$WORDS" ]; then
+    DUP="$(gh issue list --repo "$REPO" --state open --search "in:title $WORDS" \
+      --json number --jq "[.[] | select(.number != $ISSUE)] | .[0].number // empty" 2>/dev/null || echo '')"
+    if is_int "$DUP"; then
+      say "🔎 This looks similar to #$DUP — if it's the same request, consider continuing there."
+      add_label "possible-duplicate"
+    fi
+  fi
+fi
+
+emit true "ok"
+exit 0

--- a/.github/workflows/pm-intake.yml
+++ b/.github/workflows/pm-intake.yml
@@ -28,7 +28,18 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+      # Phase 3.1 (control #11): rate limit / daily cap / new-account friction /
+      # dedupe for the open intake. proceed=false skips the agent run.
+      - name: Abuse gate
+        id: abuse
+        env:
+          ISSUE: ${{ github.event.issue.number }}
+          ACTOR: ${{ github.event.issue.user.login }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: .github/scripts/abuse-gate.sh
+
       - name: Build prompt
+        if: steps.abuse.outputs.proceed == 'true'
         id: load
         env:
           ISSUE_BODY: ${{ github.event.issue.body }}
@@ -52,6 +63,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Run Codex (PM agent)
+        if: steps.abuse.outputs.proceed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -68,7 +80,7 @@ jobs:
             "$PROMPT"
 
       - name: Auto-merge spec PR (PAT cascade to dev-implement)
-        if: success()
+        if: success() && steps.abuse.outputs.proceed == 'true'
         env:
           GH_TOKEN: ${{ secrets.AUTO_PAT }}
           ISSUE: ${{ github.event.issue.number }}

--- a/docs/security-implementation-plan.md
+++ b/docs/security-implementation-plan.md
@@ -111,10 +111,20 @@ branches `codex/issue-*`.
 ## Phase 3 — abuse / PM controls & observability
 
 **3.1 — PM sprawl & abuse controls** *(#11)*
-- change: bounded rounds → `needs-human`; structured PRD-complete checklist gate; dedupe; per-author +
-  global rate limits; cost circuit-breaker (daily metered-spend cap → freeze + alert); third-party comments
-  gated on write-permission; metered key treated as burnable (caps, rotation).
-- done-check: an issue can't loop forever; a duplicate is linked+closed; spend cap trips the freeze.
+- shipped: `.github/scripts/abuse-gate.sh`, wired into `pm-intake` (the open, unauthenticated entry point —
+  it runs the agent on every new issue from anyone). Enforces, all **fail-open** on API error:
+  per-author **rate limit** (issues/24h) → skip + `rate-limited`; **daily intake cap** (runs/day, the
+  cost/abuse breaker — subscription has no $ meter) → skip + `needs-human`; **new-account friction**
+  (account age < N days) → `discussion-only` label (PM still answers = discussion); **dedupe**
+  (title-overlap with an open issue) → non-blocking `possible-duplicate` comment. Thresholds tunable via
+  env (`NEW_ACCOUNT_DAYS=30`, `AUTHOR_ISSUES_24H=5`, `DAILY_INTAKE_CAP=50`).
+- remaining: bounded PM **conversation rounds** in `pm-followup` (cap bot replies → `needs-human`) —
+  meaningful once PM conversation is opened to non-write issue authors (today `pm-followup` is write-gated
+  by `authorize.sh`); the structured PRD-complete checklist gate; honoring `discussion-only` in the dev
+  advance path; closing (not just flagging) confirmed duplicates.
+- done-check: a flood of issues from one author is rate-limited; >cap runs/day pauses intake; a brand-new
+  account's issue is `discussion-only`; a near-duplicate is flagged. Verified the gate's branches with a
+  stubbed `gh`.
 
 **3.2 — observability, kill switch, alerts, new-account friction** *(#13/#15/#16)*
 - change: Langfuse tracing with redaction + retention + **no tracing of secret jobs**; `agents:freeze`


### PR DESCRIPTION
## what

`pm-intake` runs the PM agent on **every new issue from anyone** (no auth gate) — the open untrusted entry point. This adds a pre-flight **abuse gate** (control #11).

`.github/scripts/abuse-gate.sh` (all **fail-open** on API error — never locks out legit users):
- **per-author rate limit** (issues/24h) → skip + `rate-limited`
- **daily intake cap** (runs/day — the cost/abuse circuit-breaker; subscription has no $ meter) → skip + `needs-human`
- **new-account friction** (account age < `NEW_ACCOUNT_DAYS`) → `discussion-only` label (PM still answers = discussion)
- **dedupe** (title overlap with an open issue) → non-blocking `possible-duplicate` comment

Thresholds tunable via env: `NEW_ACCOUNT_DAYS=30`, `AUTHOR_ISSUES_24H=5`, `DAILY_INTAKE_CAP=50`.

`pm-intake.yml`: the gate runs first; **Build prompt / Run Codex / Auto-merge spec** are gated on `proceed == 'true'`.

## safety

The gate never merges or changes code — worst case it **skips an agent run**. Verified the decision branches with a stubbed `gh` (rate-limit / daily-cap → `false`; normal / new-account / duplicate → `true`). `secret-segmentation` guard still green.

## remaining 3.1 (noted in plan)

Bounded **conversation rounds** in `pm-followup` (meaningful once PM is opened to non-write authors — today it's write-gated); structured PRD-complete checklist; honoring `discussion-only` in the dev advance path; closing confirmed duplicates.

Telegram/Langfuse (3.2 alerts/tracing) intentionally skipped per your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)