### PR TITLE
feat(web): HUD GitHub link (#37)

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -12,6 +12,8 @@
     #name { background: #0c0f14; color: #cfe; }
     button { background: #3CB44B; color: #06210c; border: none; cursor: pointer; }
     #hud { position: fixed; top: 8px; left: 8px; color: #9fb6c4; z-index: 5; font: 14px system-ui; }
+    #gh-link { position: fixed; bottom: 8px; left: 8px; z-index: 5; color: #9fb6c4; text-decoration: none; font: 13px system-ui; opacity: 0.7; }
+    #gh-link:hover { opacity: 1; text-decoration: underline; }
   </style>
 </head>
 <body>
@@ -22,6 +24,7 @@
     </form>
   </div>
   <div id="hud"></div>
+  <a id="gh-link" href="https://github.com/MishaMgla/opencraft1/" target="_blank" rel="noopener noreferrer">GitHub</a>
   <script type="module" src="./src/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Implements #37 (spec: docs/specs/2026-06-21-issue-37-hud-github-link.md).

Adds a minimal fixed GitHub link in the bottom-left corner over the game viewport, linking to `https://github.com/MishaMgla/opencraft1/`.

- Static DOM anchor in `web/index.html` (`position: fixed; bottom/left: 8px`), so it stays anchored during camera/player movement and on resize.
- Low-chrome styling matching the existing top-left `#hud` (muted color, 0.7 opacity, underline on hover). No new panel/modal.
- Opens in a new tab (`target="_blank" rel="noopener noreferrer"`); no game state, networking, or name-entry changes.
- Web unit tests pass (8/8).

Note: the automated dev run on #37 failed at the verification gate because the runner has no Go installed (`go.mod present but 'go' is not installed`) — unrelated to this web-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)