### PR TITLE
docs(project-map): note HUD GitHub link (#37)

### DIFF
--- a/docs/project-map/README.md
+++ b/docs/project-map/README.md
@@ -39,6 +39,7 @@ docs/project-map/
 
 Reverse-chronological. Tracks doc-structure changes and shipped feature milestones. When a branch is named, the work has not merged to `main` yet. New entries go on top; one line per entry; dates are absolute (YYYY-MM-DD).
 
+- 2026-06-21: add a minimal fixed bottom-left GitHub repository link over the web game viewport (issue #37).
 - 2026-06-20 (branch `chore/cruft-audit-cleanup`): PM product-scope guardrail — the PM agent now softly redirects "start over" issues (rebuild from scratch, wipe the codebase, pivot to a different project) toward a concrete game-improving alternative instead of drafting a spec, and never closes/locks them (that stays the security classifier's job). Rule in `AGENT_RULES.md` ("product scope"); new redirect mode in `self-audit.md` + `pm-system.md`, backstop in `pm-draft-spec.md`; intake `ACTION` line updated.
 - 2026-06-19: repo cruft audit — removed the dead Next.js-oriented index generator (`scripts/build-index.ts`) and its empty `docs/project-map/index/` output (the repo is Go + vanilla TS, not a Next.js App Router tree), purged accidentally-committed `.playwright-mcp/` session dumps (now gitignored), refreshed this file's stale "no source tree yet" boilerplate, and added `Status:` headers to historical plans/specs.
 - 2026-06-16: add engine `/version` endpoint — returns deployed commit SHA and build timestamp as JSON, with Railway Docker builds stamping metadata via ldflags.

--- a/docs/project-map/client.md
+++ b/docs/project-map/client.md
@@ -10,7 +10,7 @@ TypeScript source compiled in-place to ESM by `tsc` (no bundler). Emitted `.js` 
 - `input.ts` — keyboard state → local movement integration (client-authoritative).
 - `render.ts` — PixiJS app (loaded from the jsdelivr prebuilt ESM bundle): static iso floor, player tokens (shape + shadow + label), depth-sorted by world position, camera follow.
 - `main.ts` — orchestration: name-entry → connect → per-frame loop (move, interpolate remotes, center camera, rate-limited input send). resolves the socket URL via `config.ts` (`resolveWsUrl()`) before connecting. exposes live `{me, others, bounds}` on `window.__game` when `window.__E2E` is set, for the Playwright smoke test (`web/e2e/`); inert otherwise.
-- `index.html` — name-entry overlay + HUD + module entry.
+- `index.html` — name-entry overlay + top-left HUD + fixed bottom-left GitHub repository link + module entry.
 
 ## sharp edges
 - remote players are smoothed toward the latest snapshot (`rx += (tx-rx)*0.2`); not time-based interpolation — good enough for MVP.


### PR DESCRIPTION
Ports the project-map doc updates from the superseded bot PR #39 onto main, adjusted so the changelog entry reflects that the feature merged (PR #40) rather than referencing an unmerged branch.

Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)