### PR TITLE
fix(agent-flow): treat "model is at capacity" as a recoverable Codex block

### DIFF
--- a/.github/scripts/codex-quota-classify.sh
+++ b/.github/scripts/codex-quota-classify.sh
@@ -1,20 +1,26 @@
 #!/usr/bin/env bash
 # codex-quota-classify.sh — decide whether a captured `codex exec` log indicates
-# the Codex subscription's usage quota was exhausted (a 429 usage-limit block),
-# as opposed to a genuine agent/build failure.
+# a transient, recoverable backend condition (the Codex subscription's usage
+# quota was exhausted, OR the selected model was temporarily at capacity), as
+# opposed to a genuine agent/build failure.
 #
 # Usage:  codex-quota-classify.sh [LOGFILE]      # reads stdin if LOGFILE omitted
-# Exit:   0 = quota-blocked   1 = not quota-blocked (genuine failure / clean)
+# Exit:   0 = recoverable backend block   1 = not (genuine failure / clean)
 #
-# Only meaningful to call on a non-zero `codex exec`; a quota block is a 429 with
-# a `usage_limit_reached` error, rendered as "You've hit your usage limit…", and
-# after Codex's internal retries as "exceeded retry limit, last status: 429".
+# Only meaningful to call on a non-zero `codex exec`. Two recoverable shapes:
+#   - quota block: a 429 with a `usage_limit_reached` error, rendered as "You've
+#     hit your usage limit…", and after Codex's internal retries as "exceeded
+#     retry limit, last status: 429".
+#   - capacity block: "Selected model is at capacity. Please try a different
+#     model." — a transient availability error that, like a quota block, clears
+#     on its own and should pause-and-retry rather than hard-fail the pipeline.
+# Both route through the same pause/auto-resume recovery path.
 # See docs/superpowers/specs/2026-06-20-codex-quota-recovery-design.md.
 set -uo pipefail
 
-# Canonical quota signatures (case-insensitive). Kept specific enough that an
-# unrelated "rate limiting" in agent output does not false-positive.
-QUOTA_RE='usage_limit_reached|usage limit|exceeded retry limit, last status: 429|429 too many requests'
+# Canonical recoverable-block signatures (case-insensitive). Kept specific enough
+# that an unrelated "rate limiting" in agent output does not false-positive.
+QUOTA_RE='usage_limit_reached|usage limit|exceeded retry limit, last status: 429|429 too many requests|model is at capacity'
 
 read_log() {
   if [ "$#" -ge 1 ] && [ -n "${1:-}" ]; then cat -- "$1"; else cat; fi
@@ -22,7 +28,7 @@ read_log() {
 
 match="$(read_log "$@" | grep -ioE "$QUOTA_RE" | head -1 || true)"
 if [ -n "$match" ]; then
-  echo "codex-quota-classify: quota block detected (matched: $match)" >&2
+  echo "codex-quota-classify: recoverable backend block detected (matched: $match)" >&2
   exit 0
 fi
 exit 1

--- a/.github/scripts/test/codex-quota-classify.test.sh
+++ b/.github/scripts/test/codex-quota-classify.test.sh
@@ -30,6 +30,8 @@ assert 0 "retry limit exhausted 429" \
   'codex: exceeded retry limit, last status: 429 Too Many Requests'
 assert 0 "case-insensitive USAGE LIMIT" \
   'ERROR: USAGE LIMIT REACHED for this account'
+assert 0 "model at capacity" \
+  'ERROR: Selected model is at capacity. Please try a different model.'
 
 # --- genuine failures (expect exit 1) ---
 assert 1 "go build error" \

--- a/docs/superpowers/specs/2026-06-20-codex-quota-recovery-design.md
+++ b/docs/superpowers/specs/2026-06-20-codex-quota-recovery-design.md
@@ -80,11 +80,13 @@ instead of inlining the command. Responsibilities:
 - Run `codex exec` (passing through model / sandbox / reasoning args), teeing
   combined stdout+stderr to a log file.
 - On non-zero exit, classify the log:
-  - **Quota block** if it matches any of `usage_limit_reached`,
+  - **Recoverable backend block** if it matches any of `usage_limit_reached`,
     `You've hit your usage limit`, `exceeded retry limit, last status: 429`
     (and, when `--json` is enabled, the structured `usage_limit_reached` error
-    event — preferred). → emit step output `quota_blocked=true` and **exit 0**,
-    so the caller marks-and-pauses instead of tripping the generic failure path.
+    event — preferred), **or** `Selected model is at capacity` (a transient
+    model-availability error that, like a quota block, clears on its own). →
+    emit step output `quota_blocked=true` and **exit 0**, so the caller
+    marks-and-pauses instead of tripping the generic failure path.
   - **Genuine failure** otherwise → exit non-zero → existing failure-comment
     path fires unchanged. No resume marker is written (never auto-retry broken
     code).


### PR DESCRIPTION
## Problem

Issue #71's `pm-followup` (mode=question, converting the owner's "B" answer into a spec) hard-failed in run [28021657243](https://github.com/MishaMgla/opencraft1/actions/runs/28021657243):

```
ERROR: Selected model is at capacity. Please try a different model.
##[error]Codex run failed (exit 1) — not a quota block; see log above.
```

`codex-quota-classify.sh` only recognized 429/usage-limit signatures, so this **transient** availability error fell through to the genuine-failure path: the pipeline hard-failed and posted a `PM followup failed` comment instead of pausing and auto-resuming.

## Fix

- Broaden `codex-quota-classify.sh` to also match `model is at capacity`, routing it through the existing pause → mark → cron-resume recovery path (same mechanism as a quota block — both are transient backend blocks that clear on their own).
- Add a regression test (`codex-quota-classify.test.sh`).
- Update the quota-recovery design spec to document the capacity signature.

## Test

```
$ bash .github/scripts/test/codex-quota-classify.test.sh
passed=9 failed=0
```

Issue #71's followup was separately re-dispatched ([run 28033874787](https://github.com/MishaMgla/opencraft1/actions/runs/28033874787)) to unblock it now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)