### PR TITLE
fix: PixelLab asset-generation correctness + size-consistency hardening

### DIFF
--- a/.github/prompts/dev-system.md
+++ b/.github/prompts/dev-system.md
@@ -15,12 +15,13 @@ A spec PR for issue #<N> has merged to `main`. Implement it:
    run the following from the repo root BEFORE writing any other code:
 
    ```
-   node web/tools/gen-asset.mjs --type <type> --name <name> --prompt "<prompt>" --size <size> [--directions <n>] [--frames <n>]
+   node web/tools/gen-asset.mjs --type <type> --name <name> --prompt "<prompt>" --size <size> [--directions <n>]
    ```
 
    map block fields to flags exactly: `type→--type`, `name→--name`,
-   `prompt→--prompt`, `size→--size`, `directions→--directions` (character only),
-   `frames→--frames` (effect only). then:
+   `prompt→--prompt`, `size→--size`, `directions→--directions` (character only).
+   `type` is `tile` | `character` | `hud`; **`effect` is not supported** (the tool
+   rejects it — `/animate-with-text` needs a base sprite). then:
 
    - confirm the PNG(s) appear under `web/assets/<type-dir>/` and that
      `web/assets/manifest.json` gained the `<type>:<name>` entry.

--- a/.github/prompts/pm-draft-spec.md
+++ b/.github/prompts/pm-draft-spec.md
@@ -28,32 +28,38 @@ Produce a spec and open a PR:
 
 ## graphics / asset generation
 
-if the issue requests game graphics — a tile, character, hud element, or effect —
+if the issue requests game graphics — a tile, character, or hud element —
 include exactly one `## Asset Generation` block **per asset** anywhere in the spec
-body (after Requirements). use this exact format (all six fields, in order):
+body (after Requirements). use this exact format (fields in order):
 
 ```
 ## Asset Generation
-- type: character        # one of: tile | character | hud | effect
+- type: character        # one of: tile | character | hud
 - name: knight           # lowercase slug [a-z0-9-]+, unique
-- prompt: armored medieval knight, front view, clean silhouette
-- size: 64               # tile/hud <=128, character <=64 per direction
+- prompt: armored medieval knight, pixel art, bold dark outline, flat shading, no background, top-down view
+- size: 64               # tile/hud 32..128, character 32..64 per direction
 - directions: 4          # character only (4 in v1)
-- frames: 6              # effect only (<=12)
 ```
 
 rules you must follow when writing this block:
 
-- `type` is exactly one of `tile` | `character` | `hud` | `effect`.
+- `type` is exactly one of `tile` | `character` | `hud`.
+  **`effect` (animated VFX) is NOT yet supported** — `/animate-with-text`
+  animates an existing sprite and needs a base reference image, so scratch
+  effect generation is rejected by the tool. Do not emit an `effect` block.
 - `name` is a lowercase slug matching `[a-z0-9-]+` and must be unique across
   all assets in the spec.
-- size caps: `tile` ≤ 128, `hud` ≤ 128, `character` ≤ 64 per direction,
-  `effect` frames ≤ 12.
+- sizes: `tile` 32–128, `hud` 32–128, `character` 32–64 per direction. these are
+  the renderer's product caps; the tool enforces them.
+- **style cohesion** — so generated assets read as ONE art set, every `prompt`
+  must carry the same style rubric phrases: `pixel art`, a consistent outline
+  (`bold dark outline`), shading (`flat shading`), `no background`, and a camera
+  cue (`top-down view`). vary only the subject. (a shared palette / style-lock is
+  a future enhancement; the prompt rubric is today's cohesion lever.)
 - write a vivid, specific `prompt` — the issue author can correct it via a
   follow-up comment before the spec PR merges; the prompt lives in the spec
   precisely so it is reviewable.
-- omit `directions` for non-character assets; omit `frames` for non-effect
-  assets.
+- omit `directions` for non-character assets.
 - the Dev agent parses this block to drive `web/tools/gen-asset.mjs`; the
   format is a machine contract — do not deviate.
 

--- a/AGENT_RULES.md
+++ b/AGENT_RULES.md
@@ -28,10 +28,11 @@ the security classifier (which handles spam / abuse / injection / malicious code
 
 - **in scope:** anything that extends or improves opencraft1 as it is — new
   gameplay surface, rendering/UX, netcode, persistence, an additive roadmap layer,
-  bug fixes, performance, polish. graphics/asset requests (a tile, character, hud
-  element, or effect) are explicitly in scope — the PM drafts an `## Asset
-  Generation` block and the Dev agent generates the art via
-  `web/tools/gen-asset.mjs`. do not redirect these as teardown or pivot.
+  bug fixes, performance, polish. graphics/asset requests (a tile, character, or
+  hud element) are explicitly in scope — the PM drafts an `## Asset Generation`
+  block and the Dev agent generates the art via `web/tools/gen-asset.mjs`. do not
+  redirect these as teardown or pivot. (animated `effect` assets are not yet
+  supported — the generator rejects them; see `.github/prompts/pm-draft-spec.md`.)
 - **out of scope (do not spec):** "start over" asks — rebuild or rewrite the
   project from scratch, wipe or mass-delete the codebase, swap opencraft1 for a
   different product/genre, or otherwise turn it into a different project. partial

--- a/web/src/assets.ts
+++ b/web/src/assets.ts
@@ -9,6 +9,11 @@ import type { Texture } from 'pixi.js';
 
 const PIXI_CDN = 'https://cdn.jsdelivr.net/npm/pixi.js@8.19.0/dist/pixi.min.mjs';
 
+export interface Placement {
+  anchor: { x: number; y: number };       // normalized canvas point pinned to the ground point
+  footprint: { w: number; h: number };    // tile cells the asset occupies
+  sortOffset: number;                      // zIndex nudge for tall/multi-cell objects
+}
 export interface AssetEntry {
   type: 'tile' | 'character' | 'hud' | 'effect';
   name: string;
@@ -17,8 +22,20 @@ export interface AssetEntry {
   directions?: number;
   fps?: number;
   size?: number;
+  placement?: Placement;
 }
 export interface Manifest { version: number; assets: Record<string, AssetEntry>; }
+
+// Backward-compatible defaults for manifests written before placement existed.
+const DEFAULT_ANCHOR: Record<AssetEntry['type'], { x: number; y: number }> = {
+  character: { x: 0.5, y: 0.8 },
+  tile: { x: 0.5, y: 0.5 },
+  effect: { x: 0.5, y: 0.5 },
+  hud: { x: 0.5, y: 0.5 },
+};
+export function anchorOf(e: AssetEntry): { x: number; y: number } {
+  return e.placement?.anchor ?? DEFAULT_ANCHOR[e.type];
+}
 
 const EMPTY: Manifest = { version: 1, assets: {} };
 
@@ -27,10 +44,10 @@ export function resolveTile(m: Manifest, name: string): { file: string } | null 
   return e?.file ? { file: e.file } : null;
 }
 export function resolveCharacter(m: Manifest, name: string):
-    { directions: number; frames: Record<string, string> } | null {
+    { directions: number; frames: Record<string, string>; anchor: { x: number; y: number } } | null {
   const e = m.assets[`character:${name}`];
   if (!e || Array.isArray(e.frames) || !e.frames) return null;
-  return { directions: e.directions ?? 4, frames: e.frames };
+  return { directions: e.directions ?? 4, frames: e.frames, anchor: anchorOf(e) };
 }
 export function resolveEffect(m: Manifest, name: string): { fps: number; frames: string[] } | null {
   const e = m.assets[`effect:${name}`];

--- a/web/src/render.ts
+++ b/web/src/render.ts
@@ -293,7 +293,7 @@ export async function createRenderer(manifest: Manifest): Promise<Renderer> {
       const tex = file ? await loadTexture(file) : null;
       if (!tex) return;
       const sprite = new Sprite(tex);
-      sprite.anchor.set(0.5, 0.8);
+      sprite.anchor.set(ch.anchor.x, ch.anchor.y);
       token.container.removeChildren();
       token.container.addChild(sprite);
     },

--- a/web/test/gen-asset.test.mjs
+++ b/web/test/gen-asset.test.mjs
@@ -54,18 +54,23 @@ test('run writes four character PNGs', async () => {
   assert.ok(existsSync(join(dir, 'characters/testknight-south.png')));
 });
 
-test('run writes effect frames and manifest entry', async () => {
-  const res = await run(
-    ['--type', 'effect', '--name', 'testspark', '--prompt', 'spark', '--frames', '3'],
+test('run rejects scratch effect generation', async () => {
+  // /animate-with-text animates an existing sprite; it can't synthesize an
+  // effect from text. Scratch effect generation must fail fast (it would 422
+  // against the real API) rather than emit an invalid request.
+  await assert.rejects(
+    run(['--type', 'effect', '--name', 'testspark', '--prompt', 'spark', '--frames', '3'],
+      { generateImpl: fakeGen, env }),
+    /not supported via scratch/,
+  );
+  assert.ok(!existsSync(join(dir, 'effects/testspark-0.png')), 'no effect files should be written');
+});
+
+test('run stamps placement metadata on entries', async () => {
+  await run(['--type', 'character', '--name', 'testmage', '--prompt', 'mage', '--size', '64', '--directions', '4'],
     { generateImpl: fakeGen, env });
-  assert.equal(res.skipped, false);
-  assert.equal(res.key, 'effect:testspark');
-  assert.ok(existsSync(join(dir, 'effects/testspark-0.png')));
-  assert.ok(existsSync(join(dir, 'effects/testspark-1.png')));
-  assert.ok(existsSync(join(dir, 'effects/testspark-2.png')));
   const m = JSON.parse(readFileSync(manifestPath(), 'utf8'));
-  const entry = m.assets['effect:testspark'];
-  assert.ok(Array.isArray(entry.frames), 'frames should be an array');
-  assert.equal(entry.frames.length, 3, 'should have 3 frames');
-  assert.ok(entry.fps, 'should have fps');
+  const entry = m.assets['character:testmage'];
+  assert.ok(entry.placement, 'entry should carry placement');
+  assert.equal(entry.placement.anchor.y, 0.8, 'character anchor.y default is 0.8');
 });

--- a/web/test/manifest.test.mjs
+++ b/web/test/manifest.test.mjs
@@ -19,3 +19,9 @@ test('enforceCaps rejects oversize tile', () => {
 test('enforceCaps rejects too many effect frames', () => {
   assert.throws(() => enforceCaps('effect', 64, 99), /frames/);
 });
+
+test('enforceCaps rejects undersize and off-fixed sizes', () => {
+  assert.throws(() => enforceCaps('tile', 16), /below min/);   // pixflux floor is 32
+  assert.throws(() => enforceCaps('effect', 32), /exactly 64/); // effect is fixed 64x64
+  assert.doesNotThrow(() => enforceCaps('effect', 64));
+});

--- a/web/tools/contract.mjs
+++ b/web/tools/contract.mjs
@@ -35,17 +35,39 @@ export const ENDPOINTS = {
 // The API returns an object keyed by these names; renderer expects this order.
 export const DIRECTIONS = ['south', 'north', 'east', 'west'];
 
+// Camera view for character generation. /create-character-with-4-directions
+// accepts "low_top_down" | "high_top_down" | "side"; the endpoint default is
+// low_top_down. For our 2:1 iso projection (KX=0.5, KY=0.25) the right value is
+// UNDECIDED — picking it needs a real generation compared against the 128x64
+// diamond grid (isometric:true and low_top_down are the first candidates). Until
+// that fixture runs (first activation), we send NO view and let the server
+// default apply. Pass an explicit `view` to override.
+//
+// Palette/colour control is intentionally NOT wired yet (deferred with the rest
+// of the set-cohesion work). When added, use the REAL per-endpoint field — it is
+// not uniform: /animate-with-text exposes `forced_palette`, while the character
+// endpoint exposes `color_image` + `force_colors`. Do not invent a shared field.
+
 // Build the POST body for a generation request.
 // "description" is the confirmed PixelLab field name (not "prompt").
-export function requestBody(type, { prompt, size, frames }) {
+export function requestBody(type, { prompt, size, view }) {
   switch (type) {
     case 'tile':
     case 'hud':
       return { description: prompt, image_size: { width: size, height: size } };
-    case 'character':
-      return { description: prompt, image_size: { width: size, height: size } };
+    case 'character': {
+      const body = { description: prompt, image_size: { width: size, height: size } };
+      if (view) body.view = view;
+      return body;
+    }
     case 'effect':
-      return { description: prompt, n_frames: frames, image_size: { width: size, height: size } };
+      // /animate-with-text ANIMATES an existing sprite — it is NOT text-to-effect.
+      // It requires `action` + `reference_image` (plus description/image_size).
+      // Scratch (reference-less) effect generation is unsupported; gen-asset.mjs
+      // rejects it upstream. This throw is defence-in-depth so we never emit the
+      // old invalid body that 422s. Re-introduce as a two-step (generate a base
+      // frame, then animate it) when object-VFX support is built.
+      throw new Error('effect: /animate-with-text requires a reference_image + action; scratch effects unsupported');
     default:
       throw new Error(`unknown asset type: ${type}`);
   }

--- a/web/tools/gen-asset.mjs
+++ b/web/tools/gen-asset.mjs
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 import { generate } from './pixellab.mjs';
 import { DIRECTIONS } from './contract.mjs';
 import {
-  assetsDir, assetKey, validateSlug, enforceCaps, readManifest, upsertManifest,
+  assetsDir, assetKey, validateSlug, enforceCaps, readManifest, upsertManifest, defaultPlacement,
 } from './manifest.mjs';
 
 const TYPE_DIR = { tile: 'tiles', character: 'characters', hud: 'hud', effect: 'effects' };
@@ -21,6 +21,7 @@ function parseArgs(argv) {
     else if (k === '--size') a.size = Number(v);
     else if (k === '--directions') a.directions = Number(v);
     else if (k === '--frames') a.frames = Number(v);
+    else if (k === '--view') a.view = v;
     else throw new Error(`unknown flag: ${k}`);
   }
   if (!a.type || !a.name || !a.prompt) throw new Error('required: --type --name --prompt');
@@ -31,6 +32,16 @@ function parseArgs(argv) {
 export async function run(argv, { generateImpl = generate, env = process.env } = {}) {
   const a = parseArgs(argv);
   validateSlug(a.name);
+  if (a.type === 'effect') {
+    // /animate-with-text animates an EXISTING sprite (requires a base
+    // reference_image + action); it cannot synthesize an effect from text
+    // alone. Reject scratch effect generation until the two-step pipeline
+    // (generate a base frame -> animate it) is built. The effect category
+    // stays in the manifest/render schema for that future path.
+    throw new Error('effect generation is not supported via scratch asset generation: '
+      + '/animate-with-text needs a base reference sprite + action. Generate the base '
+      + 'sprite first, then animate (two-step pipeline not yet built).');
+  }
   if (a.type === 'character' && a.directions !== 4) throw new Error('v1 supports 4-direction characters only (got ' + a.directions + ')');
   enforceCaps(a.type, a.size, a.frames);
   const key = assetKey(a.type, a.name);
@@ -41,11 +52,12 @@ export async function run(argv, { generateImpl = generate, env = process.env } =
   }
 
   const { images } = await generateImpl(
-    { type: a.type, prompt: a.prompt, size: a.size, frames: a.frames },
+    { type: a.type, prompt: a.prompt, size: a.size, frames: a.frames, directions: a.directions, view: a.view },
     { apiKey: env.PIXELLAB_API_KEY },
   );
 
   const dir = TYPE_DIR[a.type];
+  const placement = defaultPlacement(a.type);
   const files = [];
   let entry;
 
@@ -56,19 +68,12 @@ export async function run(argv, { generateImpl = generate, env = process.env } =
       writeFileSync(join(assetsDir(), rel), images[i]);
       frames[d] = rel; files.push(rel);
     });
-    entry = { type: 'character', name: a.name, directions: a.directions, size: a.size, frames, prompt: a.prompt };
-  } else if (a.type === 'effect') {
-    const frames = images.map((buf, i) => {
-      const rel = `${dir}/${a.name}-${i}.png`;
-      writeFileSync(join(assetsDir(), rel), buf);
-      files.push(rel); return rel;
-    });
-    entry = { type: 'effect', name: a.name, fps: 12, size: a.size, frames, prompt: a.prompt };
+    entry = { type: 'character', name: a.name, directions: a.directions, size: a.size, frames, prompt: a.prompt, placement };
   } else {
     const rel = `${dir}/${a.name}.png`;
     writeFileSync(join(assetsDir(), rel), images[0]);
     files.push(rel);
-    entry = { type: a.type, name: a.name, file: rel, size: a.size, prompt: a.prompt };
+    entry = { type: a.type, name: a.name, file: rel, size: a.size, prompt: a.prompt, placement };
   }
 
   upsertManifest(entry);

--- a/web/tools/manifest.mjs
+++ b/web/tools/manifest.mjs
@@ -13,9 +13,40 @@ export function manifestPath() {
   return join(assetsDir(), 'manifest.json');
 }
 
-export const CAPS = { tile: 128, hud: 128, character: 64, effect: 64 };
+// Per-type pixel-size rules, grounded in the live PixelLab v2 contract + our
+// isometric renderer:
+//   - tile/hud  -> /create-image-pixflux: API allows 32..400; we product-cap at 128.
+//   - character -> /create-character-with-4-directions: API min 32; we product-cap
+//                  at 64 per direction.
+//   - effect    -> /animate-with-text: documents a FIXED 64x64 frame (min == max).
+// `fixed` (when set) forces an exact dimension; otherwise [min,max] is a closed
+// range. The 128/64 ceilings are PRODUCT caps (renderer-driven), not API limits.
+export const SIZES = {
+  tile:      { min: 32, max: 128 },
+  hud:       { min: 32, max: 128 },
+  character: { min: 32, max: 64 },
+  effect:    { min: 64, max: 64, fixed: 64 },
+};
+// Back-compat: the old upper-cap map (callers/tests read CAPS.tile, etc.).
+export const CAPS = Object.fromEntries(Object.entries(SIZES).map(([t, s]) => [t, s.max]));
 export const MAX_EFFECT_FRAMES = 12;
-const TYPES = new Set(Object.keys(CAPS));
+const TYPES = new Set(Object.keys(SIZES));
+
+// Renderer placement metadata, stored per asset so the client positions sprites
+// deterministically on the iso grid. anchor = normalized canvas point pinned to
+// the world ground point; footprint = tile cells the asset occupies; sortOffset
+// nudges zIndex for tall objects (zIndex = wx+wy alone is insufficient when an
+// object spans multiple cells or rises behind/over neighbors). Backward-compatible
+// defaults: existing manifests without placement still load via these.
+export function defaultPlacement(type) {
+  switch (type) {
+    case 'character': return { anchor: { x: 0.5, y: 0.8 }, footprint: { w: 1, h: 1 }, sortOffset: 0 };
+    case 'tile':      return { anchor: { x: 0.5, y: 0.5 }, footprint: { w: 1, h: 1 }, sortOffset: 0 };
+    case 'effect':    return { anchor: { x: 0.5, y: 0.5 }, footprint: { w: 1, h: 1 }, sortOffset: 0 };
+    case 'hud':       return { anchor: { x: 0.5, y: 0.5 }, footprint: { w: 0, h: 0 }, sortOffset: 0 };
+    default:          return { anchor: { x: 0.5, y: 1.0 }, footprint: { w: 1, h: 1 }, sortOffset: 0 };
+  }
+}
 
 export function validateSlug(name) {
   if (!/^[a-z0-9-]+$/.test(name)) {
@@ -31,7 +62,12 @@ export function assetKey(type, name) {
 
 export function enforceCaps(type, size, frames = 1) {
   if (!TYPES.has(type)) throw new Error(`unknown asset type: ${type}`);
-  if (size > CAPS[type]) throw new Error(`size ${size} exceeds cap ${CAPS[type]} for ${type}`);
+  const s = SIZES[type];
+  if (s.fixed !== undefined && size !== s.fixed) {
+    throw new Error(`size ${size} invalid for ${type}: must be exactly ${s.fixed}`);
+  }
+  if (size < s.min) throw new Error(`size ${size} below min ${s.min} for ${type}`);
+  if (size > s.max) throw new Error(`size ${size} exceeds cap ${s.max} for ${type}`);
   if (type === 'effect' && frames > MAX_EFFECT_FRAMES) {
     throw new Error(`effect frames ${frames} exceed cap ${MAX_EFFECT_FRAMES}`);
   }

--- a/web/tools/pixellab.mjs
+++ b/web/tools/pixellab.mjs
@@ -3,23 +3,30 @@ import { BASE_URL, ENDPOINTS, requestBody, jobIdOf, jobDoneOf, jobFailedOf, jobI
 const realSleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 export async function generate(
-  { type, prompt, size, frames = 1 },
+  { type, prompt, size, frames = 1, directions = 4, view },
   { apiKey, fetchImpl = fetch, pollMs = 2000, timeoutMs = 300000, sleep = realSleep },
 ) {
   if (!apiKey) throw new Error('PIXELLAB_API_KEY is not set');
+  // How many images a complete result must contain. Used to distinguish a
+  // genuine inline (sync) response from a partial one returned alongside a
+  // background_job_id — we must NOT accept a half-generated character.
+  const expected = type === 'character' ? directions : type === 'effect' ? frames : 1;
   const res = await fetchImpl(`${BASE_URL}${ENDPOINTS[type]}`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${apiKey}` },
-    body: JSON.stringify(requestBody(type, { prompt, size, frames })),
+    body: JSON.stringify(requestBody(type, { prompt, size, view })),
   });
   if (!res.ok) throw new Error(`PixelLab POST ${ENDPOINTS[type]} failed: HTTP ${res.status}`);
   const post = await res.json();
   const syncImages = jobImagesOf(post);
-  if (syncImages.length > 0) {
+  // Only accept the inline response if it is COMPLETE. A short/partial images
+  // payload (e.g. a job envelope with an empty or 2-of-4 images object) falls
+  // through to polling instead of being treated as a finished sync result.
+  if (syncImages.length >= expected) {
     return { images: syncImages.map((b64) => Buffer.from(b64, 'base64')) };
   }
   const id = jobIdOf(post);
-  if (!id) throw new Error('PixelLab POST returned neither images nor a background_job_id');
+  if (!id) throw new Error('PixelLab POST returned neither a complete image set nor a background_job_id');
   const deadline = Date.now() + timeoutMs;
   for (;;) {
     const pollRes = await fetchImpl(`${BASE_URL}/background-jobs/${id}`, {
@@ -30,7 +37,9 @@ export async function generate(
     if (jobFailedOf(job)) throw new Error(`PixelLab job ${id} failed`);
     if (jobDoneOf(job)) {
       const images = jobImagesOf(job).map((b64) => Buffer.from(b64, 'base64'));
-      if (!images.length) throw new Error(`PixelLab job ${id} completed with no images`);
+      if (images.length < expected) {
+        throw new Error(`PixelLab job ${id} returned ${images.length} image(s), expected ${expected}`);
+      }
       return { images };
     }
     if (Date.now() > deadline) throw new Error(`PixelLab job ${id} timed out after ${timeoutMs}ms`);


### PR DESCRIPTION
Verified the PixelLab integration against the live v2 OpenAPI spec, then debated the design with Codex (2-round). This applies the agreed fixes. All are **contract correctness + renderer metadata + agent-doc** changes — the feature still ships **inactive** (manifest empty, procedural look is still the default), so nothing visually changes yet.

## What was wrong
- **`effect` was guaranteed to 422.** `/animate-with-text` *animates an existing sprite* (requires `reference_image` + `action`); our `effect` path sent only `{description, n_frames, image_size}`. Unit tests passed only because they mock the response.
- No min-size floor (pixflux requires ≥32), no `view`, no sprite-anchor metadata, and the inline-response path would accept a **partial** character (e.g. 2 of 4 directions).

## Fixes (7)
1. **Disable scratch `effect`, fail-fast** — `gen-asset` rejects it with a clear message; `contract.requestBody` throws as defense-in-depth. `effect` stays in the manifest/render schema for a future two-step (generate base frame → animate) pipeline.
2. **Per-type sizes** — `SIZES` table with per-type min/max; `effect` fixed at 64; pixflux floor 32. `enforceCaps` now checks floor/fixed, not just the ceiling. `CAPS` kept as a derived back-compat map.
3. **Placement metadata** — entries carry `anchor`/`footprint`/`sortOffset` with backward-compatible defaults; renderer `setSkin` uses the manifest anchor instead of a hardcoded `0.8`.
4. **Per-endpoint palette doc** — pinned the real field names (`forced_palette` vs `color_image`/`force_colors`); no uniform abstraction added.
5. **Dual-path hardening** — `generate()` requires the complete expected image count before accepting an inline response; a partial character now falls through to polling.
6. **`view` not hardcoded** — configurable `--view`, omitted by default; isometric-vs-low_top_down selection deferred to a first-activation fixture.
7. **Agent/spec docs** — PM can no longer emit an `effect` block; size rules updated; added a style-rubric cohesion lever (pixel art / bold outline / flat shading / no background / top-down view).

## Deferred (intentionally)
bitforge / style-image / palette-cohesion infrastructure, and the actual `view` value — both need real generations against a live key.

## Test
`npm run build` green; `npm test` **33/33** (added 2: effect-rejection, size-floor/fixed).

## Still open (not in this PR)
No real PixelLab call has ever run — the sync/async dual-path is unit-tested with mocks only. Needs one live generation once `PIXELLAB_API_KEY` is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- agent-bot -->