### PR TITLE
Make all game interface copy English

### DIFF
--- a/AGENT_RULES.md
+++ b/AGENT_RULES.md
@@ -21,6 +21,18 @@ single source of truth for rules and documentation pointers shared by all AI cod
 
 ## product scope (PM guardrail)
 
+### in-game language (confirmed 2026-09-10)
+
+All game-authored, player-facing text must be in English: entry screens,
+buttons, labels, placeholders, tooltips, accessibility names, help, statuses,
+errors, notifications, and generated world/artifact names and stories.
+This applies to existing and future game content on every platform, regardless
+of the player's browser language or the language used to discuss the project.
+Preserve player-authored names and messages as written; do not translate or
+restrict them. Project discussions and planning documents may remain in Russian.
+Earlier Russian UI examples in planning docs are historical, not approved copy
+for implementation. Recording this rule does not mean existing UI is translated.
+
 **Evolving-world planning (2026-09-06).** For the new player-driven world,
 start at `docs/prd/evolving-world-product-plan.md`, then read the scenario or
 visual/UX document linked there. On 2026-09-07 the user authorized implementation

--- a/docs/prd/evolving-world-product-plan.md
+++ b/docs/prd/evolving-world-product-plan.md
@@ -1,5 +1,10 @@
 # Первый играбельный мир: продуктовый план
 
+**Language requirement, 2026-09-10:** all game-authored player-facing content
+must be in English. See the canonical [language rule](../../AGENT_RULES.md#in-game-language-confirmed-2026-09-10).
+Older Russian UI examples are historical. The English interface is implemented;
+see [implementation and release status](../project-map/evolving-preview.md#english-interface--2026-09-10).
+
 **Production update, 2026-09-08:** the user explicitly requested direct production
 deployment after the preview. The first scene is now live through
 https://opencraft1.com/; [deployment status and rollback](../deploy.md) supersede

--- a/docs/prd/evolving-world-visual-ux.md
+++ b/docs/prd/evolving-world-visual-ux.md
@@ -2,6 +2,15 @@
 
 Дата: 2026-09-06. Статус: рабочее визуальное описание для обсуждения.
 
+## In-game language — confirmed 2026-09-10
+
+English is required for all game-authored player-facing text. The canonical
+[language rule](../../AGENT_RULES.md#in-game-language-confirmed-2026-09-10)
+covers UI, accessibility text and generated world content, while preserving
+player-authored names and messages. Russian UI examples below are historical
+discussion, not implementation copy. The interface translation is implemented;
+see [implementation and release status](../project-map/evolving-preview.md#english-interface--2026-09-10).
+
 ## Уточнение после игры — 2026-09-09
 
 **Уточнение о чате, 2026-09-09:** пользователь имел в виду реплику возле говорящего персонажа, как в его примере Ultima Online, а не текстовую ленту в углу. Обычный режим — временный текст над фигурой без пузыря и подложки; справа только строка ввода с кнопками. История с датами открывается отдельно. Своя реплика появляется сразу, но до ответа сервера отмечена как отправляемая. Это заменяет прежнее предложение о нескольких постоянно видимых строках справа. Открытие не меняет камеру; стик, читаемый размер текста и области нажатия сохраняются.

--- a/docs/project-map/README.md
+++ b/docs/project-map/README.md
@@ -49,6 +49,7 @@ docs/project-map/
 
 ## changelog
 
+- 2026-09-10: English-only game copy and `en-GB` chat dates, preserving player-authored content; language rule in `AGENT_RULES.md`, implementation/release record in `evolving-preview.md#english-interface--2026-09-10`.
 - 2026-09-09 (production, main `9ce13dd`): speech above the actual avatar, marked local echo, one-row composer and opt-in history. Live cursor continues while reading; transient actor IDs prevent duplicate-name confusion. Local/public checks and CI passed; deployment `66faa4f5-a50b-41b7-85dc-b45c22f58241`, release record in `../deploy.md`.
 Reverse-chronological. Tracks doc-structure changes and shipped feature milestones. When a branch is named, the work has not merged to `main` yet. New entries go on top; one line per entry; dates are absolute (YYYY-MM-DD).
 

--- a/docs/project-map/evolving-preview.md
+++ b/docs/project-map/evolving-preview.md
@@ -85,6 +85,18 @@ go run ./cmd/evolving-preview -listen 127.0.0.1:8767
 
 Остановка контейнера `sudo docker stop opencraft-evolving-preview-db` сохраняет том. Том не удалять для «перезапуска»: в нём история. Резервное копирование и восстановление ещё не отрепетированы; наличие тома не заменяет бэкап.
 
+## English interface — 2026-09-10
+
+All game-authored copy is English: entry, help/disclosures, chat controls,
+empty/history states, send/retry confirmations, connection and graphics errors,
+accessibility names, page title and description. HTML uses `lang=en`; chat dates
+use `en-GB` while retaining the player's local timezone. Player-authored names,
+drafts and messages are unchanged, including existing non-English history.
+No localization library, data migration, protocol or gameplay change is needed.
+The browser check covers English copy, accessible attributes and dates while
+deliberately sending Cyrillic player messages to verify they remain untouched.
+Production release verification will be recorded here after deployment.
+
 ## Доработка 2026-09-09
 
 Последнее уточнение: реплики появляются над говорящими персонажами, а компактный чат содержит только строку ввода и кнопки (44 px), без списка. Текст следует за фигурой, переносится и исчезает через 5–12 секунд; новая реплика заменяет предыдущую. История остаётся по кнопке ≡. Успешный статус отправки не занимает место, ошибки остаются видимыми.

--- a/web/evolving/index.html
+++ b/web/evolving/index.html
@@ -1,18 +1,18 @@
 <!doctype html>
-<html lang="ru">
+<html lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <meta name="theme-color" content="#000000">
-  <meta name="description" content="Пробная общая пустота: персонажи, движение и разговор.">
-  <title>Пустота — OpenCraft</title>
+  <meta name="description" content="A shared empty world: characters, movement and conversation.">
+  <title>The Void — OpenCraft</title>
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Cpath fill='%239BAF96' d='M16 2 27 10 23 26 10 29 5 12Z'/%3E%3C/svg%3E">
   <link rel="stylesheet" href="/evolving/style.css">
   <script type="importmap">{"imports":{"three":"/preview-vendor/three.module.js"}}</script>
 </head>
 <body>
-  <main id="world" aria-label="Общая трёхмерная пустота">
-    <canvas id="scene" aria-label="Персонажи в общем мире"></canvas>
+  <main id="world" aria-label="Shared 3D void">
+    <canvas id="scene" aria-label="Characters in the shared world"></canvas>
     <div id="labels" aria-hidden="true"></div>
   </main>
   <header id="hud" hidden>
@@ -21,48 +21,48 @@
   </header>
   <section id="entry" aria-labelledby="entry-title">
     <div class="entry-copy">
-      <p class="eyebrow">OpenCraft / пробная сцена</p>
-      <h1 id="entry-title">Пока — только мы.</h1>
-      <p>Можно идти и разговаривать.</p>
+      <p class="eyebrow">OpenCraft / early world</p>
+      <h1 id="entry-title">For now, just us.</h1>
+      <p>Walk around. Talk to each other.</p>
     </div>
     <form id="entry-form">
-      <label for="name">Как тебя называть</label>
-      <input id="name" name="name" maxlength="24" autocomplete="nickname" required placeholder="Имя">
+      <label for="name">What should we call you?</label>
+      <input id="name" name="name" maxlength="24" autocomplete="nickname" required placeholder="Name">
       <div class="entry-actions">
-        <button id="previous-look" type="button" hidden aria-label="Вернуть предыдущий облик">Назад</button>
-        <button id="reroll" type="button" disabled>Другой облик</button>
-        <button id="join" type="submit" disabled>Войти</button>
+        <button id="previous-look" type="button" hidden aria-label="Restore previous appearance">Back</button>
+        <button id="reroll" type="button" disabled>Another look</button>
+        <button id="join" type="submit" disabled>Enter</button>
       </div>
       <details id="entry-info" class="note">
-        <summary>Об игре</summary>
-        <p id="entry-note">Изолированная проба. История пока не сохраняется, эволюция ещё не подключена.</p>
+        <summary>About this world</summary>
+        <p id="entry-note">Isolated test world. Chat is not saved yet. World evolution is not connected.</p>
       </details>
     </form>
   </section>
   <div id="connection" role="status" hidden>
     <span id="connection-text"></span>
-    <button id="retry" type="button" hidden>Подключиться снова</button>
+    <button id="retry" type="button" hidden>Reconnect</button>
   </div>
   <div id="controls" hidden>
-    <button id="stick" type="button" aria-label="Движение: потяни в нужную сторону или используй стрелки">
+    <button id="stick" type="button" aria-label="Move: drag in a direction or use the arrow keys">
       <span id="stick-knob"></span>
     </button>
-    <p id="move-help" class="note">WASD / стрелки — идти</p>
+    <p id="move-help" class="note">WASD / arrows to move</p>
     <div class="conversation-control">
-      <button id="open-chat" type="button" aria-expanded="false" aria-controls="conversation">Чат <span id="unread-dot" hidden aria-hidden="true"></span></button>
+      <button id="open-chat" type="button" aria-expanded="false" aria-controls="conversation">Chat <span id="unread-dot" hidden aria-hidden="true"></span></button>
     </div>
   </div>
   <section id="conversation" aria-labelledby="conversation-title" hidden>
-    <header><h2 id="conversation-title">Разговор</h2></header>
-    <p id="history-status" class="note" role="status">Только это посещение. Сообщения пока не сохраняются.</p>
-    <div id="history-controls" hidden><button id="earlier" type="button">Раньше</button><button id="latest" type="button" hidden>К свежим</button></div>
-    <ol id="messages" tabindex="0" aria-label="Сообщения разговора"><li id="empty-chat" class="note">Здесь ещё никто не написал.</li></ol>
+    <header><h2 id="conversation-title">Conversation</h2></header>
+    <p id="history-status" class="note" role="status">This visit only. Messages are not saved yet.</p>
+    <div id="history-controls" hidden><button id="earlier" type="button">Earlier</button><button id="latest" type="button" hidden>Latest</button></div>
+    <ol id="messages" tabindex="0" aria-label="Chat messages"><li id="empty-chat" class="note">No messages yet.</li></ol>
     <form id="message-form">
-      <label class="sr-only" for="message">Сообщение</label>
-      <input id="message" name="message" maxlength="200" autocomplete="off" placeholder="Сообщение…" disabled>
-      <button id="send" type="submit" aria-label="Отправить" title="Отправить" disabled>↑</button>
-      <button id="expand-chat" type="button" aria-label="Открыть историю" title="Открыть историю" aria-expanded="false" aria-controls="messages">≡</button>
-      <button id="close-chat" type="button" aria-label="Закрыть разговор" title="Закрыть разговор">×</button>
+      <label class="sr-only" for="message">Message</label>
+      <input id="message" name="message" maxlength="200" autocomplete="off" placeholder="Message…" disabled>
+      <button id="send" type="submit" aria-label="Send" title="Send" disabled>↑</button>
+      <button id="expand-chat" type="button" aria-label="Open history" title="Open history" aria-expanded="false" aria-controls="messages">≡</button>
+      <button id="close-chat" type="button" aria-label="Close chat" title="Close chat">×</button>
     </form>
     <p id="delivery" class="note" role="status"></p>
   </section>
@@ -71,8 +71,8 @@
       const status = document.getElementById('connection');
       status.hidden = false;
       document.getElementById('connection-text').textContent = String(error).includes('WebGL')
-        ? 'Не удалось включить 3D. Попробуй браузер с поддержкой WebGL 2.'
-        : 'Не удалось загрузить сцену. Проверь сборку клиента и обнови страницу.';
+        ? 'Could not start 3D. Try a browser that supports WebGL 2.'
+        : 'Could not load the world. Check your connection and reload.';
     });
   </script>
 </body>

--- a/web/src/evolving/conversation.ts
+++ b/web/src/evolving/conversation.ts
@@ -62,16 +62,16 @@ export function savedConversation(append: (name: string, text: string, record: S
           if (record.playerId !== guest?.id) speak(record);
         }
         // Freeze the displayed page when reading above its end. No eviction of
-        // the line being read; the existing cursor API reloads on "К свежим".
+        // the line being read; the existing cursor API reloads on "Latest".
         if (!live || ((!get('conversation').classList.contains('expanded') || get('conversation').hidden) && get('conversation').dataset.reading === 'true') ||
           (!get('conversation').hidden && get('conversation').classList.contains('expanded') && list.scrollHeight - list.scrollTop - list.clientHeight >= 40)) {
           live = false;
-          historyStatus.textContent = 'Есть новые сообщения — «К свежим».';
+          historyStatus.textContent = 'New messages — select Latest.';
           return;
         }
       }
       if (before && !records.length) {
-        historyStatus.textContent = 'Это начало разговора.';
+        historyStatus.textContent = 'This is the start of the conversation.';
       } else {
         if (reset || before) list.replaceChildren();
         if (reset) cursor = records[records.length - 1]?.id || '';
@@ -83,13 +83,13 @@ export function savedConversation(append: (name: string, text: string, record: S
         if (!list.children.length) {
           const empty = document.createElement('li');
           empty.id = 'empty-chat'; empty.className = 'note';
-          empty.textContent = 'Здесь ещё никто не написал.'; list.append(empty);
+          empty.textContent = 'No messages yet.'; list.append(empty);
         }
-        historyStatus.textContent = live ? 'Сохранённый разговор. Доступен всем участникам пробы.' : 'Прошлые сообщения. Новые — по кнопке «К свежим».';
+        historyStatus.textContent = live ? 'Saved chat. Visible to everyone in this world.' : 'Older messages. Select Latest for new ones.';
         if (reset || before) list.scrollTop = before ? 0 : list.scrollHeight;
       }
     } catch {
-      if (attempt === epoch) { historyStatus.textContent = 'Не удалось обновить историю. Показанный текст остаётся на экране.'; historyStatus.classList.add('error'); }
+      if (attempt === epoch) { historyStatus.textContent = 'Could not refresh history. The messages already shown are still here.'; historyStatus.classList.add('error'); }
     } finally {
       reading = false;
       earlier.disabled = !connected || !list.firstElementChild?.getAttribute('data-message-id');
@@ -115,7 +115,7 @@ export function savedConversation(append: (name: string, text: string, record: S
     sending = true; send.disabled = true;
     ownSpeech(text, 'pending');
     delivery.dataset.state = 'pending';
-    delivery.textContent = storageOK ? 'Отправляется…' : 'Отправляется… Не закрывай страницу: черновик не сохраняется.';
+    delivery.textContent = storageOK ? 'Sending…' : 'Sending… Keep this page open: your draft cannot be saved.';
     try {
       const saved: SavedMessage = await previewRequest('messages', request);
       if (saved.playerId !== guest.id || saved.requestId !== request.requestId || saved.text !== request.text) throw new Error('invalid acknowledgement');
@@ -123,14 +123,14 @@ export function savedConversation(append: (name: string, text: string, record: S
       pending = undefined; remember();
       ownSpeech(text, 'saved');
       delivery.dataset.state = 'saved';
-      delivery.textContent = 'Сохранено в разговоре.';
+      delivery.textContent = 'Saved to chat.';
     } catch (error) {
       ownSpeech(text, 'error');
       delivery.dataset.state = 'error';
       delivery.textContent = error instanceof Error && error.message === '429'
-        ? 'Подожди немного и отправь снова. Текст остался в поле.'
-        : 'Подтверждения нет. Можно повторить: то же сообщение не запишется дважды.';
-      if (!storageOK) delivery.textContent += ' Не перезагружай страницу: браузер не сохраняет черновик.';
+        ? 'Wait a moment and try again. Your text is still in the field.'
+        : 'Not confirmed. You can retry: the same message will not be saved twice.';
+      if (!storageOK) delivery.textContent += ' Do not reload: this browser cannot save your draft.';
     } finally { sending = false; send.disabled = !connected; }
   });
 
@@ -143,7 +143,7 @@ export function savedConversation(append: (name: string, text: string, record: S
           if (draft && typeof draft.text === 'string') input.value = draft.text.slice(0, 200);
           if (draft?.pending && /^[a-f0-9]{32}$/.test(draft.pending.requestId) && typeof draft.pending.text === 'string') {
             pending = draft.pending;
-            delivery.textContent = 'Осталась неподтверждённая отправка. Повтор не создаст вторую запись.';
+            delivery.textContent = 'An earlier send is unconfirmed. Retrying will not create a duplicate.';
           }
         } catch { /* Optional local draft; ownership is in the HttpOnly cookie. */ }
       }

--- a/web/src/evolving/main.ts
+++ b/web/src/evolving/main.ts
@@ -67,7 +67,7 @@ function status(text: string, canRetry = false) {
   retry.hidden = !canRetry;
 }
 function updatePresence() {
-  element('presence').textContent = online ? `В мире: ${actors.size + 1}` : 'Нет соединения';
+  element('presence').textContent = online ? `In the world: ${actors.size + 1}` : 'Disconnected';
 }
 function stopMoving() {
   input.clear();
@@ -93,7 +93,7 @@ function restoreScroll() {
 }
 function unread(value: boolean) {
   element('unread-dot').hidden = !value;
-  openChat.setAttribute('aria-label', value ? 'Разговор: новые сообщения' : 'Открыть разговор');
+  openChat.setAttribute('aria-label', value ? 'Chat: new messages' : 'Open chat');
 }
 function setChat(open: boolean) {
   rememberScroll();
@@ -101,7 +101,7 @@ function setChat(open: boolean) {
   if (!open) expanded = false;
   conversation.classList.toggle('expanded', expanded);
   expandChat.textContent = expanded ? '−' : '≡';
-  expandChat.title = expanded ? 'Уменьшить историю' : 'Открыть историю';
+  expandChat.title = expanded ? 'Collapse history' : 'Open history';
   expandChat.setAttribute('aria-label', expandChat.title);
   expandChat.setAttribute('aria-expanded', String(expanded));
   openChat.hidden = open;
@@ -124,7 +124,7 @@ expandChat.addEventListener('click', () => {
   if (expanded) { stopMoving(); unread(false); }
   conversation.classList.toggle('expanded', expanded);
   expandChat.textContent = expanded ? '−' : '≡';
-  expandChat.title = expanded ? 'Уменьшить историю' : 'Открыть историю';
+  expandChat.title = expanded ? 'Collapse history' : 'Open history';
   expandChat.setAttribute('aria-label', expandChat.title);
   expandChat.setAttribute('aria-expanded', String(expanded));
   viewport();
@@ -171,7 +171,7 @@ function choiceControls() {
   reroll.disabled = starting || !verified;
   previousLook.hidden = !canChoose || !previousLooks.length;
   previousLook.disabled = starting;
-  joinButton.textContent = guest && !guest.appearanceChoicePending ? 'Вернуться' : 'Войти';
+  joinButton.textContent = guest && !guest.appearanceChoicePending ? 'Return' : 'Enter';
   viewport();
 }
 reroll.addEventListener('click', () => {
@@ -202,11 +202,11 @@ function loseConnection() {
   sendButton.disabled = true;
   joinButton.disabled = false;
   choiceControls();
-  if (pending) delivery.textContent = 'Доставка не подтверждена. Черновик сохранён в поле; повтор может создать дубликат.';
+  if (pending) delivery.textContent = 'Delivery unconfirmed. Your draft is still in the field; retrying may create a duplicate.';
   pending = '';
   clearTimeout(deliveryTimer);
   updatePresence();
-  status(persistent ? 'Соединения с миром нет. Если гость открыт в другой вкладке, закрой её и подключись снова.' : 'Соединение прервалось. Мир недоступен, текст остался на экране.', true);
+  status(persistent ? 'Disconnected from the world. If this guest is open in another tab, close it and reconnect.' : 'Connection lost. The world is unavailable; your text is still here.', true);
 }
 
 function appendMessage(name: string, text: string, record?: { id: string; createdAt: string }) {
@@ -220,7 +220,7 @@ function appendMessage(name: string, text: string, record?: { id: string; create
     li.dataset.messageId = record.id;
     const time = document.createElement('time');
     time.dateTime = record.createdAt;
-    time.textContent = ` · ${new Date(record.createdAt).toLocaleString('ru-RU', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })}`;
+    time.textContent = ` · ${new Date(record.createdAt).toLocaleString('en-GB', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })}`;
     author.append(time);
   }
   li.append(author, document.createTextNode(text));
@@ -236,7 +236,7 @@ function appendMessage(name: string, text: string, record?: { id: string; create
     clearTimeout(deliveryTimer);
     if (messageInput.value.trim() === pending) messageInput.value = '';
     pending = '';
-    delivery.textContent = 'Получено сервером. История пока не сохраняется.';
+    delivery.textContent = 'Received by the server. Chat history is not saved yet.';
     // Match the existing server's chat throttle without pretending rejected sends succeeded.
     sendButton.disabled = true;
     deliveryTimer = window.setTimeout(() => { sendButton.disabled = !online; }, 650);
@@ -254,7 +254,7 @@ async function join() {
   reroll.disabled = true;
   previousLook.disabled = true;
   joinedName = name;
-  status('Соединяемся с общей пустотой…');
+  status('Connecting to the shared world…');
   input.clear();
   for (const actor of actors.values()) scene.remove(actor);
   actors.clear();
@@ -281,7 +281,7 @@ async function join() {
       showLook();
     } catch {
       clearTimeout(timeout); loseConnection();
-      status('Не удалось восстановить гостя. Проверь соединение и повтори вход.', true);
+      status('Could not restore your guest. Check your connection and try entering again.', true);
       return;
     }
   }
@@ -306,7 +306,7 @@ async function join() {
       const previous = actors.get(message.id);
       if (previous) scene.remove(previous);
       const recipe = /^(shape|shape2)-([a-f0-9]{1,8})$/.exec(message.character);
-      if (!recipe) { fatal = true; network?.close(); stopMoving(); status('Обнови страницу: в мире появились новые формы.', true); retry.textContent = 'Перезагрузить'; return; }
+      if (!recipe) { fatal = true; network?.close(); stopMoving(); status('Reload the page: new character forms are available.', true); retry.textContent = 'Reload'; return; }
       const actorSeed = Number.parseInt(recipe[2]!, 16) >>> 0;
       const actor = scene.makeAvatar(actorSeed, message.name, recipe[1] === 'shape' ? 1 : 2);
       actor.x = actor.tx = message.x; actor.y = actor.ty = message.y;
@@ -345,13 +345,13 @@ element<HTMLFormElement>('message-form').addEventListener('submit', event => {
   if (!text || !online || sendButton.disabled || pending) return;
   pending = text;
   sendButton.disabled = true;
-  delivery.textContent = 'Отправляется…';
+  delivery.textContent = 'Sending…';
   scene.say(me, text, 'pending');
   network?.sendChat(text);
   deliveryTimer = window.setTimeout(() => {
     pending = '';
     sendButton.disabled = !online;
-    delivery.textContent = 'Доставка не подтверждена. Повторная отправка может создать дубликат.';
+    delivery.textContent = 'Delivery unconfirmed. Sending again may create a duplicate.';
     scene.say(me, text, 'error');
   }, 5000);
 });
@@ -360,8 +360,8 @@ canvas.addEventListener('webglcontextlost', event => {
   savedChat?.stop();
   event.preventDefault(); fatal = true; online = false; input.clear(); network?.close();
   messageInput.disabled = true; sendButton.disabled = true;
-  status('Графическая сцена остановилась. Для восстановления перезагрузи страницу.', true);
-  retry.textContent = 'Перезагрузить';
+  status('The 3D scene stopped. Reload the page to recover.', true);
+  retry.textContent = 'Reload';
 });
 
 let lastTime = performance.now();
@@ -394,8 +394,8 @@ try {
       // Backlog after a network gap belongs in history, not above today's head.
       if (actor && Date.now() - Date.parse(record.createdAt) < 15000) scene.say(actor, record.text);
     }, (text, state) => scene.say(me, text, state));
-    element('entry-note').textContent = 'Гость закреплён за этим браузером на 30 дней. Разговор сохраняется и доступен участникам и оператору пробы; автоудаления пока нет. Эволюция не подключена.';
-    element('history-status').textContent = 'Сохранённый разговор загрузится после входа.';
+    element('entry-note').textContent = 'Your guest belongs to this browser for 30 days. Chat is saved and visible to all participants and the test operator; messages are not automatically deleted. World evolution is not connected.';
+    element('history-status').textContent = 'Saved chat will load after you enter.';
     try {
       guest = await previewRequest('session');
       nameInput.value = guest!.name; nameInput.readOnly = true;
@@ -409,8 +409,8 @@ try {
   choiceControls(); viewport();
 } catch {
   fatal = true;
-  status(persistent ? 'Не удалось загрузить гостя. Проверь сервер пробы и перезагрузи страницу.' : 'Нужен отдельный сервер пробной сцены. Обычный сервер игры не подключён.', persistent);
-  if (persistent) retry.textContent = 'Перезагрузить';
+  status(persistent ? 'Could not load your guest. Check your connection and reload.' : 'This scene needs its own test server. The regular game server is not connected.', persistent);
+  if (persistent) retry.textContent = 'Reload';
 }
 
 window.addEventListener('pagehide', () => { generation++; savedChat?.stop(); network?.close(); scene.dispose(); });

--- a/web/tools/check-evolving-ui.mjs
+++ b/web/tools/check-evolving-ui.mjs
@@ -12,10 +12,21 @@ const run = (...args) => execFileSync('agent-browser', ['--session', session, ..
 const peer = (...args) => execFileSync('agent-browser', ['--session', `${session}-peer`, ...args], { encoding: 'utf8', timeout: 45000 });
 let peerOpened = false;
 const evaluate = code => JSON.parse(run('eval', code));
+function checkEnglish() {
+  assert.equal(evaluate('document.documentElement.lang'), 'en');
+  const copy = evaluate(`(() => {
+    const nodes = [...document.querySelectorAll('button, label, [role=status], .entry-copy, #entry-info, #move-help, #empty-chat, #messages time')];
+    const attributes = [...document.querySelectorAll('[aria-label], [placeholder], [title]')]
+      .flatMap(e => ['aria-label', 'placeholder', 'title'].map(a => e.getAttribute(a) || ''));
+    return [document.title, ...nodes.map(e => e.textContent), ...attributes].join(' ');
+  })()`);
+  assert.doesNotMatch(copy, /[А-Яа-яЁё]/u, 'game copy must be English; player names and messages are excluded');
+}
 try {
   run('open', origin);
   run('set', 'viewport', '390', '844');
   run('wait', '--fn', '!document.querySelector("#join").disabled');
+  checkEnglish();
   assert.equal(evaluate('document.querySelector("#appearance-note, #keep-look") !== null'), false);
   assert.equal(evaluate('document.querySelector("#entry-info").open'), false);
   for (const [width, height] of [[320,568], [390,844], [844,390], [1280,800]]) {
@@ -112,6 +123,7 @@ try {
   run('click', '#expand-chat');
   assert.equal(evaluate('document.querySelector("#conversation").classList.contains("expanded")'), true);
   assert.equal(evaluate('getComputedStyle(document.querySelector("#messages time")).display'), 'inline');
+  checkEnglish();
   run('screenshot', '/tmp/opencraft-ui-history.png');
   run('eval', 'document.querySelector("#messages").scrollTop = 75');
   const readingPosition = () => evaluate(`(() => {
@@ -160,9 +172,11 @@ try {
   })()`), true);
   run('eval', 'window.fetch = window.originalFetch; window.releaseSend()');
   run('wait', '--fn', 'document.querySelector("#delivery").dataset.state === "error"');
+  checkEnglish();
   assert.equal(evaluate('document.querySelector("#message").value'), 'Проверка компактной отправки');
   run('click', '#send');
-  run('wait', '--fn', 'document.querySelector("#message").value === "" && document.querySelector("#delivery").textContent === "Сохранено в разговоре."');
+  run('wait', '--fn', 'document.querySelector("#message").value === "" && document.querySelector("#delivery").textContent === "Saved to chat."');
+  checkEnglish();
   assert.equal(evaluate('document.activeElement.id'), 'message');
   assert.equal(evaluate('document.querySelector(".player-speech[data-state=saved]").textContent'), 'Проверка компактной отправки');
   run('screenshot', '/tmp/opencraft-ui-speech.png');


### PR DESCRIPTION
Translate entry, chat, accessibility labels, metadata, errors and statuses. Use English dates without changing timezone or player-authored names/messages. Record the English-only language requirement in the agent rules and product plans. No dependencies, schema, protocol or gameplay changes. Validated: 42 client tests, Go build/test/vet, four-viewport browser checks, failed-send recovery, duplicate-name speech and English-copy checks with Cyrillic player messages preserved. Local screenshots: /tmp/opencraft-entry-320.png and /tmp/opencraft-ui-history.png. Production delivery uses the existing manual Railway archive workflow after merge.