### PR TITLE
Remove About this world from the entry screen

### DIFF
--- a/docs/prd/evolving-world-visual-ux.md
+++ b/docs/prd/evolving-world-visual-ux.md
@@ -2,6 +2,13 @@
 
 Дата: 2026-09-06. Статус: рабочее визуальное описание для обсуждения.
 
+## Entry simplification — confirmed 2026-09-10
+
+The user requested removing the entire “About this world” block, not relocating
+or collapsing it. Remove the heading, explanatory copy and associated behavior.
+This supersedes the earlier entry-disclosure placement below. Guest ownership,
+chat storage and world-evolution status do not change.
+
 ## In-game language — confirmed 2026-09-10
 
 English is required for all game-authored player-facing text. The canonical

--- a/docs/project-map/README.md
+++ b/docs/project-map/README.md
@@ -49,6 +49,7 @@ docs/project-map/
 
 ## changelog
 
+- 2026-09-10: remove the entire “About this world” entry block, related copy, toggle listener and CSS; update four-viewport browser checks. Storage behavior is unchanged.
 - 2026-09-10 (production, main `cb73fce`, PR #155): English-only game copy and `en-GB` chat dates, preserving player-authored content; local/CI/public read-only checks passed. Deployment `d363676f-d796-427e-8bf7-433ca3161b88`; current release record in `evolving-preview.md#english-interface--2026-09-10`.
 - 2026-09-09 (production, main `9ce13dd`): speech above the actual avatar, marked local echo, one-row composer and opt-in history. Live cursor continues while reading; transient actor IDs prevent duplicate-name confusion. Local/public checks and CI passed; deployment `66faa4f5-a50b-41b7-85dc-b45c22f58241`, release record in `../deploy.md`.
 Reverse-chronological. Tracks doc-structure changes and shipped feature milestones. When a branch is named, the work has not merged to `main` yet. New entries go on top; one line per entry; dates are absolute (YYYY-MM-DD).

--- a/docs/project-map/evolving-preview.md
+++ b/docs/project-map/evolving-preview.md
@@ -85,6 +85,15 @@ go run ./cmd/evolving-preview -listen 127.0.0.1:8767
 
 Остановка контейнера `sudo docker stop opencraft-evolving-preview-db` сохраняет том. Том не удалять для «перезапуска»: в нём история. Резервное копирование и восстановление ещё не отрепетированы; наличие тома не заменяет бэкап.
 
+## Entry simplification — 2026-09-10
+
+Removed the entire “About this world” details block at the user's request,
+including both memory-mode and persistent-mode copy, its toggle listener and
+unused styles. Nothing replaces it. The chooser still fits the available space
+between the heading and form. Browser checks now assert the block is absent
+and check all four viewport sizes without an expanded-disclosure variant.
+Storage behavior is unchanged; the entry no longer displays the storage notice.
+
 ## English interface — 2026-09-10
 
 All game-authored copy is English: entry, help/disclosures, chat controls,
@@ -160,7 +169,7 @@ API версии 2: создание сессии требует `avatarVersion:
 
 Позиция записывается при отключении и штатной остановке сервера. Принудительное завершение процесса или недоступная база могут потерять перемещение после последнего сохранения. Имя, облик и уже подтверждённые сообщения записываются сразу. Ошибка базы не останавливает движение уже подключённых игроков, но блокирует восстановление гостя и подтверждение нового сообщения.
 
-Нет артефактов, звука, агента эволюции, автоматического выпуска и полноценной защиты публичного сервиса. Беседа доступна всем гостям и оператору пробы; автоматического удаления нет — это указано в раскрываемом «Об игре» до входа. Перед приглашением реальных участников ещё нужны политика хранения/удаления, резервное восстановление и проверка настоящих телефонов.
+Artifacts, sound, world evolution, automated releases and comprehensive public-service protection are not implemented. Chat is visible to all guests and the test operator, with no automatic deletion. The entry notice was removed at the user's request on 2026-09-10; storage/retention policy, backup restoration and real-phone checks remain outstanding before wider invitations.
 
 В режиме **без базы** всё ещё используется эфемерный бинарный чат без ID сообщений. Только 200 строк текущего посещения, повтор может дублироваться, черновик не переживает перезагрузку. Его интерфейс прямо сообщает, что история не сохраняется.
 

--- a/web/evolving/index.html
+++ b/web/evolving/index.html
@@ -33,10 +33,6 @@
         <button id="reroll" type="button" disabled>Another look</button>
         <button id="join" type="submit" disabled>Enter</button>
       </div>
-      <details id="entry-info" class="note">
-        <summary>About this world</summary>
-        <p id="entry-note">Isolated test world. Chat is not saved yet. World evolution is not connected.</p>
-      </details>
     </form>
   </section>
   <div id="connection" role="status" hidden>

--- a/web/evolving/style.css
+++ b/web/evolving/style.css
@@ -31,8 +31,6 @@ label { display: block; font-size: 13px; color: var(--muted); margin-bottom: 9px
 .entry-actions { display: flex; gap: 12px; margin: 12px 0; }
 .entry-actions button { flex: 1; }
 #previous-look { flex: 0; padding-inline: .65rem; }
-#entry-info summary { cursor: pointer; width: fit-content; min-height: 44px; padding-block: 12px; }
-#entry-info p { max-height: 20dvh; overflow-y: auto; }
 #join { background: var(--accent); color: #101510; border-color: var(--accent); }
 #join:hover:not(:disabled) { background: #b0c0aa; }
 .note { color: var(--muted); font-size: 12px; }

--- a/web/src/evolving/main.ts
+++ b/web/src/evolving/main.ts
@@ -155,7 +155,6 @@ function viewport() {
   element('world').style.top = `${top}px`;
   element('world').style.height = `${Math.max(1, available - top)}px`;
 }
-element('entry-info').addEventListener('toggle', viewport);
 window.addEventListener('resize', viewport);
 window.visualViewport?.addEventListener('resize', viewport);
 window.visualViewport?.addEventListener('scroll', viewport);
@@ -394,7 +393,6 @@ try {
       // Backlog after a network gap belongs in history, not above today's head.
       if (actor && Date.now() - Date.parse(record.createdAt) < 15000) scene.say(actor, record.text);
     }, (text, state) => scene.say(me, text, state));
-    element('entry-note').textContent = 'Your guest belongs to this browser for 30 days. Chat is saved and visible to all participants and the test operator; messages are not automatically deleted. World evolution is not connected.';
     element('history-status').textContent = 'Saved chat will load after you enter.';
     try {
       guest = await previewRequest('session');

--- a/web/tools/check-evolving-ui.mjs
+++ b/web/tools/check-evolving-ui.mjs
@@ -15,7 +15,7 @@ const evaluate = code => JSON.parse(run('eval', code));
 function checkEnglish() {
   assert.equal(evaluate('document.documentElement.lang'), 'en');
   const copy = evaluate(`(() => {
-    const nodes = [...document.querySelectorAll('button, label, [role=status], .entry-copy, #entry-info, #move-help, #empty-chat, #messages time')];
+    const nodes = [...document.querySelectorAll('button, label, [role=status], .entry-copy, #move-help, #empty-chat, #messages time')];
     const attributes = [...document.querySelectorAll('[aria-label], [placeholder], [title]')]
       .flatMap(e => ['aria-label', 'placeholder', 'title'].map(a => e.getAttribute(a) || ''));
     return [document.title, ...nodes.map(e => e.textContent), ...attributes].join(' ');
@@ -28,17 +28,14 @@ try {
   run('wait', '--fn', '!document.querySelector("#join").disabled');
   checkEnglish();
   assert.equal(evaluate('document.querySelector("#appearance-note, #keep-look") !== null'), false);
-  assert.equal(evaluate('document.querySelector("#entry-info").open'), false);
+  assert.equal(evaluate('document.querySelector("#entry-info, #entry-note")'), null);
   for (const [width, height] of [[320,568], [390,844], [844,390], [1280,800]]) {
     run('set', 'viewport', String(width), String(height));
-    for (const open of [true, false]) {
-      run('eval', `document.querySelector('#entry-info').open = ${open}`);
-      run('wait', '--fn', `(() => {
-        const scene = document.querySelector('#world').getBoundingClientRect();
-        return scene.top >= document.querySelector('.entry-copy').getBoundingClientRect().bottom &&
-          scene.height > 20 && Math.abs(scene.bottom - document.querySelector('#entry-form').getBoundingClientRect().top) < 2;
-      })()`);
-    }
+    run('wait', '--fn', `(() => {
+      const scene = document.querySelector('#world').getBoundingClientRect();
+      return scene.top >= document.querySelector('.entry-copy').getBoundingClientRect().bottom &&
+        scene.height > 20 && Math.abs(scene.bottom - document.querySelector('#entry-form').getBoundingClientRect().top) < 2;
+    })()`);
     assert.equal(evaluate('document.documentElement.scrollWidth > innerWidth'), false);
     run('screenshot', `/tmp/opencraft-entry-${width}.png`);
   }


### PR DESCRIPTION
Remove the entire details block, both explanatory texts, its toggle listener and unused CSS. No replacement block, storage changes or new dependencies. Update the UX brief and project map to supersede the previous disclosure placement. Validated: 42 client tests, Go test/vet and the browser scenario (entry at four sizes, join, chat, history, send recovery and speech). Screenshot: /tmp/opencraft-entry-320.png. Deploy to the existing Railway production service after checks and merge; record the deployment result in this PR.